### PR TITLE
fix: copy package json in lib folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepare": "bob build",
+      "prepare": "bob build; cp package.json lib",
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",


### PR DESCRIPTION
### Context :

To solve this issue : https://github.com/Purchasely/Purchasely-ReactNative/issues/21

Compiled files in /lib/ don't know where to look out for the package.json. The import path is just copied (`../package.json`) and then compiled files can't find the package.json anymore, which is in fact in `../../package.json`.

I tried to tweak the react-native-builder-bob configuration, but it's not flexible enough to do so.

### Solution :

The easiest solution is to copy package.json in `/lib` after build.