### PR TITLE
New start method

### DIFF
--- a/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
+++ b/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
@@ -125,6 +125,7 @@ class PurchaselyModule internal constructor(context: ReactApplicationContext) : 
     return result
   }
 
+  @Deprecated("Should use start method", ReplaceWith("start"))
   @ReactMethod
   fun startWithAPIKey(apiKey: String,
                       stores: ReadableArray,
@@ -134,6 +135,18 @@ class PurchaselyModule internal constructor(context: ReactApplicationContext) : 
                       bridgeVersion: String,
                       promise: Promise) {
 
+    start(apiKey, stores, false, userId, logLevel, runningMode, bridgeVersion, promise)
+  }
+
+  @ReactMethod
+  fun start(apiKey: String,
+            stores: ReadableArray,
+            storeKit1: Boolean,
+            userId: String?,
+            logLevel: Int,
+            runningMode: Int,
+            bridgeVersion: String,
+            promise: Promise) {
     Purchasely.Builder(reactApplicationContext.applicationContext)
       .apiKey(apiKey)
       .stores(getStoresInstances(stores.toArrayList()))

--- a/purchasely/example/src/App.tsx
+++ b/purchasely/example/src/App.tsx
@@ -31,13 +31,14 @@ const App: React.FunctionComponent = () => {
     async function setupPurchasely() {
       var configured = false;
       try {
-        configured = await Purchasely.startWithAPIKey(
-          'fcb39be4-2ba4-4db7-bde3-2a5a1e20745d',
-          ['Google'],
-          null,
-          LogLevels.DEBUG,
-          RunningMode.FULL
-        );
+        configured = await Purchasely.start({
+          apiKey: 'fcb39be4-2ba4-4db7-bde3-2a5a1e20745d',
+          logLevel: LogLevels.DEBUG, // to force log level for debug
+          userId: 'test-user', // if you know your user id
+          runningMode: RunningMode.FULL, // to set mode manually
+          storeKit1: false, // default is StoreKit2
+          stores: ['Google'] // set null if you are app is only available on iOS
+        });
       } catch (e) {
         console.log('Purchasely SDK configuration errror', e);
       }
@@ -45,6 +46,8 @@ const App: React.FunctionComponent = () => {
       if (!configured) {
         console.log('Purchasely SDK not properly initialized');
       }
+
+      Purchasely.userLogout();
 
       setAnonymousUserId(await Purchasely.getAnonymousUserId());
 

--- a/purchasely/src/index.ts
+++ b/purchasely/src/index.ts
@@ -357,6 +357,9 @@ export type PurchaselyPresentation = {
   plans?: string[] | null;
 };
 
+/**
+ * @deprecated Use `start()` instead
+ **/
 function startWithAPIKey(
   apiKey: string,
   stores: string[],
@@ -373,6 +376,34 @@ function startWithAPIKey(
     purchaselyVersion
   );
 }
+
+interface StartParameters {
+  apiKey: string;
+  stores?: string[] | null;
+  storeKit1?: boolean | null;
+  userId?: string | null;
+  logLevel?: number | null;
+  runningMode?: number | null;
+}
+
+const start = ({
+  apiKey,
+  stores = ['Google'],
+  storeKit1 = false,
+  userId = null,
+  logLevel = LogLevels.ERROR,
+  runningMode = RunningMode.FULL,
+}: StartParameters): Promise<boolean> => {
+  return NativeModules.Purchasely.start(
+    apiKey,
+    stores,
+    storeKit1,
+    userId,
+    logLevel,
+    runningMode,
+    purchaselyVersion
+  );
+};
 
 function setUserAttributeWithDate(key: string, value: Date): void {
   const dateAsString = value.toISOString();
@@ -586,6 +617,7 @@ const showPresentation = () => {
 const Purchasely = {
   ...RNPurchasely,
   startWithAPIKey,
+  start,
   addEventListener,
   removeEventListener,
   addPurchasedListener,


### PR DESCRIPTION
Replace `Purchasely.startWithApiKey()` with `Purchasely.start()` to make all arguments optional except ApiKey

Allow user to force StoreKit 1 for iOS

```typescript
await Purchasely.start({
  apiKey: 'fcb39be4-2ba4-4db7-bde3-2a5a1e20745d',
  logLevel: LogLevels.DEBUG, // to force log level for debug
  userId: 'test-user', // if you know your user id
  runningMode: RunningMode.FULL, // to set mode manually
  storeKit1: false, // default is StoreKit2
  androidStores: ['Google', 'Huawei'] // Google is already set by default
});
```