### PR TITLE
docs(readme): update sdk installation doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ try {
 
 ## 🏁 Documentation
 
-A complete documentation is available on our website [https://docs.purchasely.com](https://docs.purchasely.com/quick-start/sdk-installation/react-native-sdk)
+A complete documentation is available on our website [https://docs.purchasely.com](https://docs.purchasely.com/quick-start-1/sdk-installation/react-native-sdk)


### PR DESCRIPTION
Your current link for the sdk installation doc is outdated, leads to a 404.

Added the right link: https://docs.purchasely.com/quick-start-1/sdk-installation/react-native-sdk