### PR TITLE
Fix android build for React Native 0.77.0

### DIFF
--- a/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
+++ b/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
@@ -190,7 +190,7 @@ class PurchaselyModule internal constructor(context: ReactApplicationContext) : 
             promise: Promise) {
     Purchasely.Builder(reactApplicationContext.applicationContext)
       .apiKey(apiKey)
-      .stores(getStoresInstances(stores.toArrayList()))
+      .stores(getStoresInstances(stores.toArrayList().filterNotNull() as ArrayList<Any>))
       .userId(userId)
       .logLevel(LogLevel.values()[logLevel])
       .runningMode(when(runningMode) {


### PR DESCRIPTION
As of React Native 0.77.0, the android build fail because of a type mismatch:

```
e: file:///node_modules/react-native-purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt:193:34 Argument type mismatch: actual type is 'java.util.ArrayList<kotlin.Any?>', but 'java.util.ArrayList<kotlin.Any>' was expected.
```

This PR only filter `null` elements out of the `ArrayList` then cast the new `List` to the `ArrayList` that `getStoresInstances` is expected.