### PR TITLE
fix(android): remove deprecated jcenter() repository

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -117,7 +117,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     google()
-    jcenter()
 }
 
 dependencies {

--- a/packages/purchasely/android/build.gradle
+++ b/packages/purchasely/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     google()
     mavenLocal()
     mavenCentral()
-    jcenter()
   }
 
   dependencies {
@@ -62,7 +61,6 @@ android {
 repositories {
   mavenLocal()
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
## Summary
- Remove all `jcenter()` repository declarations from Gradle files
- jcenter has been sunset since February 2021 and is no longer maintained
- All dependencies are already available via `mavenCentral()` and `google()`

### Files changed
- `packages/purchasely/android/build.gradle` — removed 2 jcenter() entries (buildscript + repositories)
- `example/android/app/build.gradle` — removed 1 jcenter() entry

## Test plan
- [ ] Android example app builds successfully (`yarn example:android`)
- [ ] `./gradlew testDebugUnitTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)