### PR TITLE
fix(deps): update fast-xml-parser to 5.6.0 (CVE-2026-33349)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,6 +2025,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@nodable/entities@npm:1.1.0"
+  checksum: 06ae11766102d4d0414d2b7760f895c26e9034cec430de042da6d30f4657d7d9d4f005e0966797e3bb949ba45874e5fc02927d4a62ac6ea096873a7eeca5752c
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -6575,15 +6582,16 @@ __metadata:
   linkType: hard
 
 "fast-xml-parser@npm:>=4.5.4":
-  version: 5.5.6
-  resolution: "fast-xml-parser@npm:5.5.6"
+  version: 5.6.0
+  resolution: "fast-xml-parser@npm:5.6.0"
   dependencies:
+    "@nodable/entities": ^1.1.0
     fast-xml-builder: ^1.1.4
-    path-expression-matcher: ^1.1.3
-    strnum: ^2.1.2
+    path-expression-matcher: ^1.5.0
+    strnum: ^2.2.3
   bin:
     fxparser: src/cli/cli.js
-  checksum: c27820af9cfc534fd40e798852601568c4078694e4d6850dad8feb94f835a0230b115f98f8660cd114c360e60f0dd09e695031cee23a3d1e78609e5538d23ef4
+  checksum: e12b7daeb532d64befe68bf51b9c06190c09e14e91c7bb3437cc3d73288acfe42b319e3ff5c8d5560dbec80ec24c11d38fd206459b435dab9159b55869efc133
   languageName: node
   linkType: hard
 
@@ -10767,6 +10775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 52f0491a88f728f2eefb83a5c4f84f1185a8572e34ba41a72f88e270d5796c966ec1fe78e978599c490ccac0656a4cc55d75485538393873d32a4ef096a8dda6
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -12474,10 +12489,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "strnum@npm:2.2.0"
-  checksum: cf9fda01ab16e1295db16a8f62b852fd92f3ed9ef940b4326a0053e3e658e7b35de82c2cac6ad946dcf6b6044d4d804845baae4659f7afcb4cdc3dcf2870d152
+"strnum@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: e8deb0dd6f40e4a878bdd4404bdfdd47922665fcaaf27f2b345013b30d45d86f4b93d99cbc005bfb7c96edef6173369bd76a9df40bb7758850b7864075a28156
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Updates `fast-xml-parser` from 5.5.6 to 5.6.0
- Resolves [Dependabot alert #649](https://github.com/Purchasely/Purchasely-ReactNative/security/dependabot/649) — **CVE-2026-33349** (medium severity): entity expansion limits bypassed when set to zero due to JavaScript falsy evaluation
- This is the last remaining open Dependabot alert on this repo

## Test plan
- [x] `yarn test` — 139/139 tests pass
- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — passes
- [ ] CI passes (lint, test, build-android, build-ios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)