### PR TITLE
fix(deps): resolve all Dependabot security alerts

### DIFF
--- a/test-projects/expo-purchasely-test/package-lock.json
+++ b/test-projects/expo-purchasely-test/package-lock.json
@@ -3128,9 +3128,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/test-projects/expo-purchasely-test/package.json
+++ b/test-projects/expo-purchasely-test/package.json
@@ -25,7 +25,7 @@
   "private": true,
   "overrides": {
     "@isaacs/brace-expansion": ">=5.0.1",
-    "@xmldom/xmldom": ">=0.8.12",
+    "@xmldom/xmldom": ">=0.9.10",
     "brace-expansion": "~1.1.13",
     "fast-xml-parser": ">=4.5.4",
     "flatted": ">=3.3.4",

--- a/test-projects/expo-purchasely-test/package.json
+++ b/test-projects/expo-purchasely-test/package.json
@@ -27,7 +27,7 @@
     "@isaacs/brace-expansion": ">=5.0.1",
     "@xmldom/xmldom": ">=0.9.10",
     "brace-expansion": "~1.1.13",
-    "fast-xml-parser": ">=4.5.4",
+    "fast-xml-parser": ">=5.7.0",
     "flatted": ">=3.3.4",
     "minimatch": ">=3.1.3",
     "node-forge": ">=1.4.0",

--- a/test-projects/rn-purchasely-test/package-lock.json
+++ b/test-projects/rn-purchasely-test/package-lock.json
@@ -2556,9 +2556,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "devOptional": true,
       "funding": [
         {
@@ -5873,9 +5873,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "devOptional": true,
       "funding": [
         {
@@ -5889,9 +5889,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
       "devOptional": true,
       "funding": [
         {
@@ -5901,8 +5901,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/test-projects/rn-purchasely-test/package.json
+++ b/test-projects/rn-purchasely-test/package.json
@@ -39,7 +39,7 @@
   },
   "overrides": {
     "brace-expansion": "~1.1.13",
-    "fast-xml-parser": ">=4.5.4",
+    "fast-xml-parser": ">=5.7.0",
     "flatted": ">=3.3.4",
     "lodash": ">=4.18.0",
     "minimatch": ">=3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2025,10 +2025,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nodable/entities@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@nodable/entities@npm:1.1.0"
-  checksum: 06ae11766102d4d0414d2b7760f895c26e9034cec430de042da6d30f4657d7d9d4f005e0966797e3bb949ba45874e5fc02927d4a62ac6ea096873a7eeca5752c
+"@nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: ae5a432a665d210bb28b3a9dbe8caf49f46be65fdc626bd14febe8f150b735182efb6967fe12f8c8f39d22e572b8b9361b4915aec094f8cea5e01f683191cf80
   languageName: node
   linkType: hard
 
@@ -6572,26 +6572,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
     path-expression-matcher: ^1.1.3
-  checksum: 90b019ed6f52cb30342a58d4bf8726a7723b4110cb9c0fd3fa2031e87506e8b18740fd349472926c9e2925d22ca6637b6d46a20eda537473cf63366970db4d7b
+  checksum: 02ea4ea959ed985033895a2000555c22f91f93e30376f7e11ee384f3839f5af3c97a8a646e4d6ba585a9b42e949b13ec89ce8bda061ee48b32a1b49f1c713372
   languageName: node
   linkType: hard
 
 "fast-xml-parser@npm:>=4.5.4":
-  version: 5.6.0
-  resolution: "fast-xml-parser@npm:5.6.0"
+  version: 5.7.2
+  resolution: "fast-xml-parser@npm:5.7.2"
   dependencies:
-    "@nodable/entities": ^1.1.0
-    fast-xml-builder: ^1.1.4
+    "@nodable/entities": ^2.1.0
+    fast-xml-builder: ^1.1.5
     path-expression-matcher: ^1.5.0
     strnum: ^2.2.3
   bin:
     fxparser: src/cli/cli.js
-  checksum: e12b7daeb532d64befe68bf51b9c06190c09e14e91c7bb3437cc3d73288acfe42b319e3ff5c8d5560dbec80ec24c11d38fd206459b435dab9159b55869efc133
+  checksum: 6ef5c57be6234de514e55d834b0711358aa205e7d40e2ef975843f493efe39c4d00f869e94eb8b48fecb4f67694fa442b798a991b53a28f173dcbc929f55dea4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `fast-xml-parser` to 5.7.2 in `yarn.lock` and `test-projects/rn-purchasely-test/package-lock.json` (alerts #655, #656 — vulnerable < 5.7.0).
- Bump `@xmldom/xmldom` to 0.9.10 in `test-projects/expo-purchasely-test/package-lock.json` (alerts #651–#654 — high severity, vulnerable >= 0.9.0, < 0.9.10).
- Tighten the override ranges in both `test-projects/*/package.json` files so future installs resolve to patched versions.

## Test plan
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test` (4 suites, 139 tests)
- [ ] Confirm Dependabot closes alerts #651–#656 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)