### PR TITLE
Version 5.7.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@
 
 | Property | Value |
 |----------|-------|
-| Current Version | 5.7.2 |
+| Current Version | 5.7.3 |
 | React Native | 0.79.2 |
 | TypeScript | 5.2.2 (strict mode) |
 | Node.js | v20 (see `.nvmrc`) |
 | Package Manager | Yarn 3.6.1 (workspaces) |
-| Native iOS SDK | 5.7.2 |
-| Native Android SDK | 5.7.3 |
+| Native iOS SDK | 5.7.4 |
+| Native Android SDK | 5.7.4 |
 
 ### Supported App Stores
 - Apple App Store (iOS)
@@ -388,11 +388,11 @@ Build orchestration with caching:
 ### Native Dependencies
 
 **iOS (CocoaPods):**
-- Purchasely SDK v5.7.2
+- Purchasely SDK v5.7.4
 - Deployment target: iOS 13.4
 
 **Android (Gradle):**
-- io.purchasely:core:5.7.3
+- io.purchasely:core:5.7.4
 - Min SDK: 21
 - Kotlin: 1.9+
 - Java: 11
@@ -630,6 +630,7 @@ See `VERSIONS.md` for native SDK version mapping:
 
 | React Native SDK | iOS SDK | Android SDK |
 |------------------|---------|-------------|
+| 5.7.3 | 5.7.4 | 5.7.4 |
 | 5.7.2 | 5.7.2 | 5.7.3 |
 | 5.7.1 | 5.7.1 | 5.7.1 |
 | 5.7.0 | 5.7.0 | 5.7.0 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -113,3 +113,4 @@ This file provides the underlying native SDK versions that the React Native SDK 
 | 5.7.0   | 5.7.0       | 5.7.0           |
 | 5.7.1   | 5.7.1       | 5.7.1           |
 | 5.7.2   | 5.7.2       | 5.7.3           |
+| 5.7.3   | 5.7.4       | 5.7.4           |

--- a/packages/amazon/android/build.gradle
+++ b/packages/amazon/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:amazon:5.7.3'
+  implementation 'io.purchasely:amazon:5.7.4'
 }

--- a/packages/amazon/package.json
+++ b/packages/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-amazon",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Purchasely Amazon In-App Purchases dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/android-player/android/build.gradle
+++ b/packages/android-player/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:player:5.7.3'
+  implementation 'io.purchasely:player:5.7.4'
 }

--- a/packages/android-player/package.json
+++ b/packages/android-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-android-player",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Player Android",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/packages/google/android/build.gradle
+++ b/packages/google/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:google-play:5.7.3'
+  implementation 'io.purchasely:google-play:5.7.4'
 }

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-google",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Purchasely Google Play Billing dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/huawei/android/build.gradle
+++ b/packages/huawei/android/build.gradle
@@ -65,5 +65,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:huawei-services:5.7.3'
+  implementation 'io.purchasely:huawei-services:5.7.4'
 }

--- a/packages/huawei/package.json
+++ b/packages/huawei/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-huawei",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Purchasely Huawei Mobile Services dependencies",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/android/build.gradle
+++ b/packages/purchasely/android/build.gradle
@@ -138,7 +138,7 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
-  api 'io.purchasely:core:5.7.3'
+  api 'io.purchasely:core:5.7.4'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
 
   // Test dependencies

--- a/packages/purchasely/package.json
+++ b/packages/purchasely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-purchasely",
   "title": "Purchasely React Native",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Purchasely is a solution to ease the integration and boost your In-App Purchase & Subscriptions on the App Store, Google Play Store and Huawei App Gallery.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/react-native-purchasely.podspec
+++ b/packages/purchasely/react-native-purchasely.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Purchasely", '5.7.2'
+  s.dependency "Purchasely", '5.7.4'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ios/PurchaselyTests/**/*.{h,m,mm,swift}'

--- a/packages/purchasely/src/__tests__/index.test.ts
+++ b/packages/purchasely/src/__tests__/index.test.ts
@@ -182,7 +182,7 @@ describe('Purchasely SDK', () => {
                 'test-user',
                 mockConstants.logLevelDebug,
                 mockConstants.runningModeFull,
-                '5.7.2'
+                '5.7.3'
             )
         })
 
@@ -203,7 +203,7 @@ describe('Purchasely SDK', () => {
                 null,
                 mockConstants.logLevelError,
                 mockConstants.runningModeFull,
-                '5.7.2'
+                '5.7.3'
             )
         })
 

--- a/packages/purchasely/src/__tests__/types.test.ts
+++ b/packages/purchasely/src/__tests__/types.test.ts
@@ -328,7 +328,7 @@ describe('Purchasely Types', () => {
             const event: PurchaselyEvent = {
                 name: 'PURCHASE_TAPPED',
                 properties: {
-                    sdk_version: '5.7.2',
+                    sdk_version: '5.7.3',
                     event_name: 'PURCHASE_TAPPED',
                     event_created_at_ms: 1705315200000,
                     event_created_at: '2024-01-15T12:00:00Z',
@@ -339,7 +339,7 @@ describe('Purchasely Types', () => {
             }
 
             expect(event.name).toBe('PURCHASE_TAPPED')
-            expect(event.properties.sdk_version).toBe('5.7.2')
+            expect(event.properties.sdk_version).toBe('5.7.3')
         })
     })
 

--- a/packages/purchasely/src/index.ts
+++ b/packages/purchasely/src/index.ts
@@ -28,7 +28,7 @@ import type {
   PurchaselyUserAttribute,
 } from './types';
 
-const purchaselyVersion = '5.7.2';
+const purchaselyVersion = '5.7.3';
 
 const constants = NativeModules.Purchasely.getConstants() as Constants;
 


### PR DESCRIPTION
## Summary

Release version 5.7.3 of the Purchasely React Native SDK.

### Native SDK updates
- **iOS SDK:** 5.7.2 → 5.7.4
- **Android SDK:** 5.7.3 → 5.7.4

## Files changed
- `packages/*/package.json` — bumped versions to 5.7.3
- `packages/purchasely/src/index.ts` — `purchaselyVersion` constant updated to 5.7.3
- `packages/purchasely/react-native-purchasely.podspec` — iOS dependency 5.7.4
- `packages/*/android/build.gradle` — Android SDK dependencies 5.7.4
- `VERSIONS.md` — added 5.7.3 row
- `CLAUDE.md` — version table refreshed
- Test version expectations updated

## Test plan
- [x] `yarn test` (139 tests passing)
- [x] `yarn lint` (no errors, only coverage/* warnings)
- [x] `yarn typecheck`
- [ ] CI: lint
- [ ] CI: test
- [ ] CI: build-android
- [ ] CI: build-ios

🤖 Generated with [Claude Code](https://claude.com/claude-code)