### PR TITLE
Version 5.7.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 | Property | Value |
 |----------|-------|
-| Current Version | 5.7.3 |
+| Current Version | 5.7.4 |
 | React Native | 0.79.2 |
 | TypeScript | 5.2.2 (strict mode) |
 | Node.js | v20 (see `.nvmrc`) |
@@ -630,6 +630,7 @@ See `VERSIONS.md` for native SDK version mapping:
 
 | React Native SDK | iOS SDK | Android SDK |
 |------------------|---------|-------------|
+| 5.7.4 | 5.7.4 | 5.7.4 |
 | 5.7.3 | 5.7.4 | 5.7.4 |
 | 5.7.2 | 5.7.2 | 5.7.3 |
 | 5.7.1 | 5.7.1 | 5.7.1 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -114,3 +114,4 @@ This file provides the underlying native SDK versions that the React Native SDK 
 | 5.7.1   | 5.7.1       | 5.7.1           |
 | 5.7.2   | 5.7.2       | 5.7.3           |
 | 5.7.3   | 5.7.4       | 5.7.4           |
+| 5.7.4   | 5.7.4       | 5.7.4           |

--- a/packages/amazon/package.json
+++ b/packages/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-amazon",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Amazon In-App Purchases dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/android-player/package.json
+++ b/packages/android-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-android-player",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Player Android",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-google",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Google Play Billing dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/huawei/package.json
+++ b/packages/huawei/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-huawei",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Huawei Mobile Services dependencies",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/package.json
+++ b/packages/purchasely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-purchasely",
   "title": "Purchasely React Native",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely is a solution to ease the integration and boost your In-App Purchase & Subscriptions on the App Store, Google Play Store and Huawei App Gallery.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/src/__tests__/index.test.ts
+++ b/packages/purchasely/src/__tests__/index.test.ts
@@ -182,7 +182,7 @@ describe('Purchasely SDK', () => {
                 'test-user',
                 mockConstants.logLevelDebug,
                 mockConstants.runningModeFull,
-                '5.7.3'
+                '5.7.4'
             )
         })
 
@@ -203,7 +203,7 @@ describe('Purchasely SDK', () => {
                 null,
                 mockConstants.logLevelError,
                 mockConstants.runningModeFull,
-                '5.7.3'
+                '5.7.4'
             )
         })
 

--- a/packages/purchasely/src/__tests__/types.test.ts
+++ b/packages/purchasely/src/__tests__/types.test.ts
@@ -328,7 +328,7 @@ describe('Purchasely Types', () => {
             const event: PurchaselyEvent = {
                 name: 'PURCHASE_TAPPED',
                 properties: {
-                    sdk_version: '5.7.3',
+                    sdk_version: '5.7.4',
                     event_name: 'PURCHASE_TAPPED',
                     event_created_at_ms: 1705315200000,
                     event_created_at: '2024-01-15T12:00:00Z',
@@ -339,7 +339,7 @@ describe('Purchasely Types', () => {
             }
 
             expect(event.name).toBe('PURCHASE_TAPPED')
-            expect(event.properties.sdk_version).toBe('5.7.3')
+            expect(event.properties.sdk_version).toBe('5.7.4')
         })
     })
 

--- a/packages/purchasely/src/index.ts
+++ b/packages/purchasely/src/index.ts
@@ -28,7 +28,7 @@ import type {
   PurchaselyUserAttribute,
 } from './types';
 
-const purchaselyVersion = '5.7.3';
+const purchaselyVersion = '5.7.4';
 
 const constants = NativeModules.Purchasely.getConstants() as Constants;
 


### PR DESCRIPTION
## Version 5.7.4

Bump React Native SDK to **5.7.4**.

### Native SDK updates
- **iOS SDK:** 5.7.4 (already pinned)
- **Android SDK:** 5.7.4 (already pinned)

### What's New

#### Bug fixes (from iOS 5.7.4)
- Paywall completion now reliably fires on user-initiated dismissal (sheet swipe, drawer/popin overlay tap, sheet drag)
- `closeAll` action now correctly dismisses standalone drawer/popin paywalls
- Pending purchases are preserved in `observer` and `observerStrict` modes
- Flow UI no longer collapses after back navigation + conditional toggle
- Conditional components stability: simultaneous tap + rotation, multi-audience binding
- Introductory offer eligibility: active subscribers no longer eligible in same group
- Promo-code redemption: paywall presentation attribution restored
- Selected media (`*_selected_url` images, Lottie, videos) display correctly without dedicated `styles.selected`
- Page control state reapplied after trait changes (light/dark mode)
- Fixed a UIKit rendering crash

#### Bug fixes (from Android 5.7.4)
- Anonymous → identified user transfer in PaywallObserver mode (purchases now carried over on `userLogin()`)
- Fixed `IllegalStateException: The specified child already has a parent` on rapid screen rebuild (rotation, repeated render)
- Fixed `IllegalStateException` on modal/drawer flow change after host fragment detach (fast back-press, activity teardown)

#### Improvements
- Improved internal concurrency handling in the eligibility flow (iOS)

## Test plan

- [x] `yarn test` — 139 / 139 passing
- [x] `yarn lint` — 0 errors
- [x] `yarn typecheck` — clean
- [ ] CI: lint
- [ ] CI: test
- [ ] CI: build-android
- [ ] CI: build-ios

🤖 Generated with [Claude Code](https://claude.com/claude-code)