### PR TITLE
fix(ci): use Node 24 for publish workflow + add workflow_dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,15 +42,12 @@ jobs:
 
       - name: Verify npm version (>= 11.5.1 required for trusted publishing)
         run: |
-          NPM_VERSION=$(npm --version)
+          NPM_VERSION="$(npm --version)"
           echo "npm version: $NPM_VERSION"
-          node -e "
-            const [maj, min, patch] = process.argv[1].split('.').map(Number);
-            if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) {
-              console.error('npm ' + process.argv[1] + ' is below required 11.5.1');
-              process.exit(1);
-            }
-          " "$NPM_VERSION"
+          if [ "$(printf '%s\n%s\n' "11.5.1" "$NPM_VERSION" | sort -V | head -n1)" != "11.5.1" ]; then
+            echo "::error::npm $NPM_VERSION is below required 11.5.1"
+            exit 1
+          fi
 
       - name: Build all packages
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. 5.7.3)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -25,15 +31,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Ensure npm >= 11.5.1 (required for trusted publishing)
-        run: npm install -g npm@latest
+      - name: Verify npm version (>= 11.5.1 required for trusted publishing)
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm version: $NPM_VERSION"
+          node -e "
+            const [maj, min, patch] = process.argv[1].split('.').map(Number);
+            if (maj < 11 || (maj === 11 && (min < 5 || (min === 5 && patch < 1)))) {
+              console.error('npm ' + process.argv[1] + ' is below required 11.5.1');
+              process.exit(1);
+            }
+          " "$NPM_VERSION"
 
       - name: Build all packages
         run: |
@@ -43,7 +60,7 @@ jobs:
 
       - name: Verify versions match release tag
         run: |
-          TAG="${GITHUB_REF_NAME}"
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
           for PKG in packages/purchasely packages/google packages/amazon packages/huawei packages/android-player; do
             VERSION=$(node -p "require('./$PKG/package.json').version")
             if [ "$VERSION" != "$TAG" ]; then


### PR DESCRIPTION
## Summary
- The 5.7.3 publish run [failed](https://github.com/Purchasely/Purchasely-ReactNative/actions/runs/25322031593/job/74235220820) at the *Ensure npm >= 11.5.1* step: ``npm install -g npm@latest`` crashed with ``Cannot find module 'promise-retry'`` on Node 22.22.2 — a known regression in npm self-upgrade on hosted runners.
- Switch the publish job to **Node 24** (ships with npm 11.x by default), removing the broken self-upgrade. Replaced by a fail-fast version guard.
- Add a ``workflow_dispatch`` trigger with a ``tag`` input so the publish can be retriggered for an existing release tag (e.g. 5.7.3) without recreating the GitHub release.

## Test plan
- [ ] Merge to ``main``
- [ ] Trigger via ``gh workflow run publish.yml --ref main -f tag=5.7.3``
- [ ] Confirm CI green, npm version printed >= 11.5.1, all 5 packages published with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)