### PR TITLE
fix(types): add missing placement_id to PurchaselyEventProperties

### DIFF
--- a/packages/purchasely/src/types.ts
+++ b/packages/purchasely/src/types.ts
@@ -200,6 +200,7 @@ export type PurchaselyEventProperties = {
   event_created_at_ms: number;
   event_created_at: string;
   displayed_presentation?: string;
+  placement_id?: string;
   user_id?: string;
   anonymous_user_id?: string;
   purchasable_plans?: PurchaselyEventPropertyPlan[];


### PR DESCRIPTION
## Summary

The SDK emits `placement_id` at runtime on event payloads (notably on `LINK_OPENED` events), but it is not declared on `PurchaselyEventProperties`. TypeScript consumers currently have to cast `event.properties` to access it:

```ts
const properties = event.properties as PurchaselyEvent['properties'] & {
  placement_id?: string;
};
Analytics.track('LINK_OPENED', {
  placement_id: properties.placement_id,
  // ...
});
```

This PR adds `placement_id?: string;` to the type, alongside the other presentation-context fields (`displayed_presentation`, `selected_presentation`, etc.).

## Change

```diff
   displayed_presentation?: string;
+  placement_id?: string;
   user_id?: string;
```

One-line type addition in `packages/purchasely/src/types.ts`. No runtime behavior change.

## Why optional

Other event-context properties on this type (`link_identifier`, `displayed_presentation`, `deeplink_identifier`, etc.) are all `?: string`, matching the fact that not every event carries them. `placement_id` follows the same pattern.