### PR TITLE
fix(deps): patch transitive vulns not covered by Dependabot (tar, js-yaml, ws)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,17 @@
     "flatted": ">=3.4.2",
     "handlebars": ">=4.7.9",
     "ip-address": ">=10.1.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": ">=4.2.0",
     "lodash": ">=4.18.0",
     "lodash-es": ">=4.18.0",
     "minimatch": "~3.1.3",
     "picomatch@npm:^4.0.2": "4.0.4",
     "picomatch@npm:^4.0.3": "4.0.4",
     "fast-xml-parser": ">=4.5.4",
-    "tar": ">=7.5.10",
+    "tar": ">=7.5.16",
     "tmp": ">=0.2.6",
-    "undici": ">=7.24.0"
+    "undici": ">=7.24.0",
+    "ws": "7.5.11"
   },
   "workspaces": [
     "packages/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,13 +4369,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-limiter@npm:~1.0.0":
-  version: 1.0.1
-  resolution: "async-limiter@npm:1.0.1"
-  checksum: 2b849695b465d93ad44c116220dee29a5aeb63adac16c1088983c339b0de57d76e82533e8e364a93a9f997f28bbfc6a92948cefc120652bd07f3b59f8d75cf2b
-  languageName: node
-  linkType: hard
-
 "async-retry@npm:1.3.3":
   version: 1.3.3
   resolution: "async-retry@npm:1.3.3"
@@ -8969,14 +8962,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 86bd35548a0c19cd1f5861147c09aa1f52eb0fc9464f34023524d22bbe079c62c30fd00750e63f632e8d12c12ad36ea0dd1e6bec5171c492ecad433d8db295eb
   languageName: node
   linkType: hard
 
@@ -12804,16 +12797,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:>=7.5.10":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
+"tar@npm:>=7.5.16":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": ^4.0.0
     chownr: ^3.0.0
     minipass: ^7.1.2
     minizlib: ^3.1.0
     yallist: ^5.0.0
-  checksum: 7f6785a85dd571b88985e493ec86f692962cbfa7b4017961fddfd2241e0ff3bcd89ed347f4c02b5433aa22b30cca5566e8711543df054fda8fd12425f505378f
+  checksum: 9b7f886f5ce8681a7430f80b9b377bfa498e6feb957b9afe6507db08e59d309f8546b7f76a0c2e47bdb54da4602575a5c7519e287fe94de8302e635032fc94f1
   languageName: node
   linkType: hard
 
@@ -13675,18 +13668,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^6.2.3":
-  version: 6.2.4
-  resolution: "ws@npm:6.2.4"
-  dependencies:
-    async-limiter: ~1.0.0
-  checksum: f3824313f3ad40a2bbc967e26ab139e052e39c3347ab5138fc7843595917545a749bf0753ddc3fcc29c80a10c979ef7191f243204885d57fada892b93c0cd5eb
-  languageName: node
-  linkType: hard
-
-"ws@npm:^7, ws@npm:^7.5.10":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+"ws@npm:7.5.11":
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -13695,7 +13679,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
+  checksum: 3f32457a6019e6875cc0c2a037d4b4789da22a55b7be278e78845ec7614d28eaab9b36994cfdf9a18a48fe02f11c496168354b96b6ce202f65fe414cdf96f08c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Force-patches three transitive dependency vulnerabilities in the **root `yarn.lock`** that Dependabot cannot auto-PR (Yarn-Berry transitive deps), via `resolutions` — matching the existing convention in `package.json`.

| Alert | Package | Before | After | Severity |
|-------|---------|--------|-------|----------|
| GHSA-vmf3-w455-68vh | `tar` | 7.5.10 (≤7.5.15) | **7.5.16** | medium |
| GHSA-h67p-54hq-rp68 | `js-yaml` | ^4.1.1 (4.1.1) | **4.2.0** | medium |
| GHSA-96hv-2xvq-fx4p | `ws` | 7.5.10 | **7.5.11** | high |

`@babel/core` (GHSA-4x5r-pxfx-6jf8) is already handled by merged PR #250.

### Notes
- `ws@^7.5.10` is pulled only by **dev tooling** (`metro`, `react-devtools-core`); the `ws@^6.2.3` consumers (RN dev server) are also collapsed to `7.5.11` — fine for dev-only WebSocket usage.
- Verified: `yarn typecheck`, `yarn lint`, `yarn test` (4 suites / 140 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)