### PR TITLE
feat(view): embed a preloaded request via <PLYPresentationView request={...}>

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -12,6 +12,7 @@ import Purchasely, {
     removeAllActionInterceptors,
 } from 'react-native-purchasely'
 import { PaywallScreen } from './Paywall.tsx'
+import { PaywallPreloadedScreen } from './PaywallPreloaded.tsx'
 
 const Stack = createNativeStackNavigator()
 
@@ -362,6 +363,10 @@ function App(): React.JSX.Element {
                     options={{ title: 'Welcome' }}
                 />
                 <Stack.Screen name="Paywall" component={PaywallScreen} />
+                <Stack.Screen
+                    name="PaywallPreloaded"
+                    component={PaywallPreloadedScreen}
+                />
             </Stack.Navigator>
         </NavigationContainer>
     )

--- a/example/src/Home.tsx
+++ b/example/src/Home.tsx
@@ -35,6 +35,10 @@ export const HomeScreen: React.FC<NativeStackScreenProps<any>> = ({
         { title: 'Preload Presentation', onPress: () => onPressPreload() },
         { title: 'Display Nested View', onPress: () => onPressNestedView() },
         {
+            title: 'Nested View (preloaded)',
+            onPress: () => onPressNestedViewPreloaded(),
+        },
+        {
             title: 'Close Presentation',
             onPress: () => onPressClosePresentation(),
         },
@@ -141,6 +145,14 @@ export const HomeScreen: React.FC<NativeStackScreenProps<any>> = ({
     const onPressNestedView = () => {
         // The embedded PLYPresentationView is driven by a placement id.
         navigation.navigate('Paywall', {
+            placementId: 'nested',
+        })
+    }
+
+    const onPressNestedViewPreloaded = () => {
+        // The embedded PLYPresentationView reuses a request preloaded by the
+        // screen (request.preload() → <PLYPresentationView request={...} />).
+        navigation.navigate('PaywallPreloaded', {
             placementId: 'nested',
         })
     }

--- a/example/src/PaywallPreloaded.tsx
+++ b/example/src/PaywallPreloaded.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from 'react'
+import { ActivityIndicator, Button, Text, View } from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Section } from './Section.tsx'
+import {
+    PLYPresentationView,
+    PresentationBuilder,
+    PresentationRequest,
+    PresentPresentationResult,
+    ProductResult,
+} from 'react-native-purchasely'
+
+/**
+ * Demo of the v6 embedded-view `request` prop: preload a `PresentationRequest`
+ * first, then hand it to `<PLYPresentationView request={...} />`. The native
+ * view reuses the already-preloaded presentation (resolved by `requestId`)
+ * instead of loading it a second time.
+ */
+export const PaywallPreloadedScreen: React.FC<NativeStackScreenProps<any>> = ({
+    navigation,
+    route,
+}) => {
+    const placementId: string = (route.params as any)?.placementId ?? 'nested'
+
+    const [request, setRequest] = useState<PresentationRequest | null>(null)
+    const [error, setError] = useState<string | null>(null)
+    // Keep the request across re-renders so we can close it on unmount.
+    const requestRef = useRef<PresentationRequest | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+
+        const req = PresentationBuilder.placement(placementId).build()
+        requestRef.current = req
+
+        req.preload()
+            .then((presentation) => {
+                if (cancelled) return
+                console.log(
+                    '[PaywallPreloaded] preloaded',
+                    presentation.screenId,
+                    'requestId=',
+                    req.requestId
+                )
+                setRequest(req)
+            })
+            .catch((e) => {
+                if (!cancelled) setError(String(e?.message ?? e))
+            })
+
+        return () => {
+            cancelled = true
+            requestRef.current?.close()
+        }
+    }, [placementId])
+
+    const callback = (result: PresentPresentationResult) => {
+        console.log('[PaywallPreloaded] closed, result =', result.result)
+        switch (result.result) {
+            case ProductResult.PRODUCT_RESULT_PURCHASED:
+            case ProductResult.PRODUCT_RESULT_RESTORED:
+                if (result.plan != null) {
+                    console.log('User purchased ' + result.plan.name)
+                }
+                break
+            case ProductResult.PRODUCT_RESULT_CANCELLED:
+                console.log('User cancelled')
+                break
+        }
+        navigation.goBack()
+    }
+
+    return (
+        <View style={{ flex: 1 }}>
+            <View
+                style={{
+                    flex: 2,
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    backgroundColor: '#f0f0f0',
+                }}
+            >
+                <Section>
+                    <Text>Preloaded request demo (placement: {placementId})</Text>
+                </Section>
+                <Button title="← Back" onPress={() => navigation.goBack()} />
+            </View>
+
+            {request ? (
+                <PLYPresentationView
+                    flex={7}
+                    request={request}
+                    onPresentationClosed={callback}
+                />
+            ) : (
+                <View
+                    style={{
+                        flex: 7,
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                    }}
+                >
+                    {error ? (
+                        <Text>Preload failed: {error}</Text>
+                    ) : (
+                        <>
+                            <ActivityIndicator />
+                            <Text>Preloading {placementId}…</Text>
+                        </>
+                    )}
+                </View>
+            )}
+        </View>
+    )
+}

--- a/packages/purchasely/CHANGELOG.md
+++ b/packages/purchasely/CHANGELOG.md
@@ -21,6 +21,11 @@ been removed (see Breaking changes below).
   (not at trigger) with a 5-field `PresentationOutcome`.
 - **`PresentationOutcome`**: `{ presentation, purchaseResult, plan, closeReason,
   error }`. Exclusion rule: `error != null ⇒ closeReason == null`.
+- **`<PLYPresentationView request={...} />`**: the embedded view now accepts a
+  preloaded `PresentationRequest`. It reuses the presentation already loaded by
+  `request.preload()` (resolved natively by the request's `requestId`) instead of
+  loading a second time — aligned with the native iOS/Android and Flutter SDKs.
+  `PresentationRequest` exposes a public `requestId` getter for this.
 - **`interceptAction(kind, handler)`** with typed payloads per action kind
   (`navigate`, `purchase`, `close`, `closeAll`, `openPresentation`,
   `openPlacement`, `webCheckout`, `login`, `restore`, `promoCode`). Handler

--- a/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
+++ b/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
@@ -1201,6 +1201,14 @@ fun decrementUserAttribute(key: String, value: Double, legalBasis: String?) {
     /** Loaded presentations currently associated with a JS request id. */
     private val activeLoadedPresentations = ConcurrentHashMap<String, PLYPresentation>()
 
+    /**
+     * Look up a presentation preloaded through `preloadPresentation` by its JS
+     * request id. Used by the embedded `PLYPresentationView` to reuse a
+     * presentation the JS layer already preloaded instead of loading a new one.
+     */
+    fun loadedPresentation(requestId: String): PLYPresentation? =
+      activeLoadedPresentations[requestId]
+
     /** Pending interceptor callbacks, resolved when JS calls completeActionInterceptor. */
     private val pendingActionInterceptors =
       ConcurrentHashMap<String, CompletableDeferred<PLYInterceptResult>>()

--- a/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyViewManager.kt
+++ b/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyViewManager.kt
@@ -46,6 +46,7 @@ class PurchaselyViewManager(private val reactContext: ReactApplicationContext) :
   private var propHeight: Int? = null
   private var placementId: String? = null
   private var screenId: String? = null
+  private var requestId: String? = null
 
   override fun getName(): String = "PurchaselyView"
 
@@ -129,7 +130,7 @@ class PurchaselyViewManager(private val reactContext: ReactApplicationContext) :
       promiseView = null
     }
 
-    val fragment = PurchaselyFragment(screenId, placementId, outcomeHandler)
+    val fragment = PurchaselyFragment(screenId, placementId, requestId, outcomeHandler)
 
     fm.beginTransaction()
       .setReorderingAllowed(true)
@@ -186,6 +187,11 @@ class PurchaselyViewManager(private val reactContext: ReactApplicationContext) :
     placementId = placementId ?: value?.getString("placementId")
   }
 
+  @ReactProp(name = "requestId")
+  fun setRequestId(view: FrameLayout?, value: String?) {
+    requestId = value
+  }
+
   @ReactMethod
   fun onPresentationClosed(promise: Promise) {
     promiseView = promise
@@ -217,6 +223,7 @@ class PurchaselyViewManager(private val reactContext: ReactApplicationContext) :
   class PurchaselyFragment(
     private val screenId: String?,
     private val placementId: String?,
+    private val requestId: String?,
     private val callback: (PLYPresentationOutcome) -> Unit
   ) : Fragment() {
 
@@ -227,6 +234,17 @@ class PurchaselyViewManager(private val reactContext: ReactApplicationContext) :
     ): View = FrameLayout(inflater.context)
 
     private fun attachPurchaselyView(host: ViewGroup) {
+      // v6 / iso iOS+Flutter: when a requestId is provided, reuse the
+      // presentation the JS layer already preloaded (request.preload()) instead
+      // of building + preloading a new one inside the view.
+      val preloaded = requestId?.let { PurchaselyModule.loadedPresentation(it) }
+      if (preloaded != null) {
+        val pv: PLYPresentationView? =
+          preloaded.buildView(host.context) { outcome -> callback(outcome) }
+        pv?.let { host.addView(it) }
+        return
+      }
+
       val prepared: PLYPresentationBase.Prepared = PLYPresentationBase.builder()
         .also { b ->
           placementId?.let { b.placementId(it) }

--- a/packages/purchasely/ios/PurchaselyRN.h
+++ b/packages/purchasely/ios/PurchaselyRN.h
@@ -21,4 +21,9 @@
 
 @property (nonatomic, assign) Boolean shouldEmit;
 
+/// Look up a presentation that was preloaded through `preloadPresentation:` by
+/// its bridge `requestId`. Used by the embedded `PLYPresentationView` to reuse a
+/// presentation the JS layer already preloaded (instead of loading it again).
++ (nullable id<PLYPresentation>)loadedPresentationForRequestId:(nonnull NSString *)requestId;
+
 @end

--- a/packages/purchasely/ios/PurchaselyRN.m
+++ b/packages/purchasely/ios/PurchaselyRN.m
@@ -232,6 +232,13 @@ static UIViewController *_sharedViewController;
     _presentationsLoaded = presentationsLoaded;
 }
 
++ (id<PLYPresentation>)loadedPresentationForRequestId:(NSString *)requestId {
+    if (requestId == nil) { return nil; }
+    @synchronized (kPresentationStateLock) {
+        return kPresentationsByRequest[requestId];
+    }
+}
+
 + (RCTPromiseResolveBlock)purchaseResolve {
     return _purchaseResolve;
 }

--- a/packages/purchasely/ios/PurchaselyView.swift
+++ b/packages/purchasely/ios/PurchaselyView.swift
@@ -26,7 +26,16 @@ class PurchaselyView: UIView {
       setupView()
     }
   }
-  
+
+  /// Bridge `requestId` of a presentation the JS layer already preloaded via
+  /// `request.preload()`. When set, the view reuses that loaded presentation's
+  /// controller instead of loading a new one (mirrors Android / Flutter).
+  @objc var requestId: String? {
+    didSet {
+      setupView()
+    }
+  }
+
   var onPresentationClosedPromise: RCTPromiseResolveBlock?
   
   override init(frame: CGRect) {
@@ -64,6 +73,19 @@ class PurchaselyView: UIView {
   
   private func getPresentationController(presentation: PurchaselyPresentation?,
                                          placementId: String?) -> UIViewController? {
+      // v6 / iso Flutter: when a `requestId` is provided, reuse the presentation
+      // the JS layer already preloaded (`request.preload()`) instead of loading a
+      // new one. Mirrors NativeView's `loadedPresentations[requestId]` lookup.
+      if let requestId = self.requestId,
+         let loaded = PurchaselyRN.loadedPresentation(forRequestId: requestId),
+         let controller = loaded.controller {
+          self.fetched = true
+          PurchaselyRN.purchaseResolve = { [weak self] result in
+              self?.onPresentationClosedPromise?(result)
+          }
+          return controller
+      }
+
       // Capture effective placement id before guard bindings are lost in the else branch.
       // When only the `presentation` prop is set (placementId prop is nil), we still need
       // the placement id to recreate the view controller on subsequent visits.

--- a/packages/purchasely/ios/PurchaselyViewManager.m
+++ b/packages/purchasely/ios/PurchaselyViewManager.m
@@ -13,6 +13,7 @@
 
 RCT_EXPORT_VIEW_PROPERTY(placementId, NSString)
 RCT_EXPORT_VIEW_PROPERTY(presentation, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(requestId, NSString)
 
 RCT_EXTERN_METHOD(onPresentationClosed:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 

--- a/packages/purchasely/src/__tests__/PLYPresentationView.test.tsx
+++ b/packages/purchasely/src/__tests__/PLYPresentationView.test.tsx
@@ -182,6 +182,45 @@ describe('PLYPresentationView', () => {
         })
     })
 
+    describe('request prop', () => {
+        it('should forward the request requestId to the native view', async () => {
+            // A preloaded PresentationRequest exposes a non-null `requestId`.
+            const request: any = { requestId: 'req-123' }
+
+            let tree: any
+            await act(async () => {
+                tree = create(<PLYPresentationView request={request} />)
+            })
+
+            const purchaselyView = tree.root.findByType('PurchaselyView' as any)
+            expect(purchaselyView.props.requestId).toBe('req-123')
+        })
+
+        it('should forward undefined when the request has not been preloaded', async () => {
+            // Before preload(), requestId is null — the view falls back to
+            // placementId / presentation.
+            const request: any = { requestId: null }
+
+            let tree: any
+            await act(async () => {
+                tree = create(<PLYPresentationView request={request} />)
+            })
+
+            const purchaselyView = tree.root.findByType('PurchaselyView' as any)
+            expect(purchaselyView.props.requestId).toBeUndefined()
+        })
+
+        it('should leave requestId undefined when no request is passed', async () => {
+            let tree: any
+            await act(async () => {
+                tree = create(<PLYPresentationView placementId="onboarding" />)
+            })
+
+            const purchaselyView = tree.root.findByType('PurchaselyView' as any)
+            expect(purchaselyView.props.requestId).toBeUndefined()
+        })
+    })
+
     describe('Props', () => {
         it('should accept all optional props', async () => {
             const presentation = {

--- a/packages/purchasely/src/__tests__/presentation.integration.test.ts
+++ b/packages/purchasely/src/__tests__/presentation.integration.test.ts
@@ -124,6 +124,25 @@ describe('façade · integration with native bridge', () => {
             expect(presentation.placementId).toBe('home');
         });
 
+        it('exposes requestId (null before preload, set after) for <PLYPresentationView request>', async () => {
+            const req = PresentationBuilder.placement('home').build();
+            // Null until the request is preloaded/displayed.
+            expect(req.requestId).toBeNull();
+
+            const preloadPromise = req.preload();
+            const [requestId] = native.preloadPresentation.mock.calls[0];
+            // The public getter now matches the bridge requestId — this is what
+            // the embedded view forwards to native to reuse the preloaded screen.
+            expect(req.requestId).toBe(requestId);
+
+            emit(PURCHASELY_PRESENTATION_EVENTS.LOADED, {
+                requestId,
+                presentation: fakePresentationPayload,
+            });
+            await preloadPromise;
+            expect(req.requestId).toBe(requestId);
+        });
+
         it('rejects when native emits LOADED with an error', async () => {
             const req = PresentationBuilder.placement('home').build();
             const preloadPromise = req.preload();

--- a/packages/purchasely/src/components/PLYPresentationView.tsx
+++ b/packages/purchasely/src/components/PLYPresentationView.tsx
@@ -7,12 +7,21 @@ import {
   UIManager,
 } from 'react-native';
 import type { PresentPresentationResult } from '../';
+import type { PresentationRequest } from '../presentation';
 
 const PurchaselyView = requireNativeComponent('PurchaselyView');
 
 interface PLYPresentationViewProps {
   placementId?: string; // Made optional
   presentation?: any; // Made optional
+  /**
+   * A presentation request that was already preloaded via `request.preload()`.
+   * The native view resolves the loaded presentation by the request's
+   * `requestId` (no second preload) — mirrors the full-screen builder flow.
+   * Preload before rendering; otherwise `requestId` is null and the view falls
+   * back to `placementId` / `presentation`.
+   */
+  request?: PresentationRequest;
   onPresentationClosed?: (result: PresentPresentationResult) => void;
   flex?: number;
 }
@@ -20,6 +29,7 @@ interface PLYPresentationViewProps {
 export const PLYPresentationView: React.FC<PLYPresentationViewProps> = ({
   placementId,
   presentation,
+  request,
   onPresentationClosed,
   flex = 1, // Default to 1 if not provided
 }) => {
@@ -76,6 +86,7 @@ export const PLYPresentationView: React.FC<PLYPresentationViewProps> = ({
       style={{ flex }}
       placementId={placementId}
       presentation={presentation}
+      requestId={request?.requestId ?? undefined}
       {...(Platform.OS === 'android' && { ref: ref })}
     />
   );

--- a/packages/purchasely/src/presentation.ts
+++ b/packages/purchasely/src/presentation.ts
@@ -231,7 +231,7 @@ export class PresentationRequest {
     /** @internal */
     private readonly config: BuilderConfig;
     /** @internal */
-    private requestId: string | null = null;
+    private _requestId: string | null = null;
     /** @internal */
     private subscriptions: EmitterSubscription[] = [];
     /** @internal */
@@ -239,6 +239,16 @@ export class PresentationRequest {
 
     constructor(config: BuilderConfig) {
         this.config = config;
+    }
+
+    /**
+     * The bridge correlation id for this request, or `null` until the request
+     * has been preloaded/displayed. Pass the request itself to
+     * `<PLYPresentationView request={...} />` to embed a presentation that was
+     * already preloaded — the view resolves it natively by this id.
+     */
+    get requestId(): string | null {
+        return this._requestId;
     }
 
     /**
@@ -359,25 +369,25 @@ export class PresentationRequest {
      * calling `close()` on one will also dismiss the others.
      */
     close(): void {
-        if (!this.requestId) {
+        if (!this._requestId) {
             return;
         }
-        NativeModules.Purchasely.closePresentation(this.requestId);
+        NativeModules.Purchasely.closePresentation(this._requestId);
     }
 
     /** Navigate back inside a multi-step (Flow) presentation. */
     back(): void {
-        if (!this.requestId) {
+        if (!this._requestId) {
             return;
         }
-        NativeModules.Purchasely.goBackToPreviousScreen(this.requestId);
+        NativeModules.Purchasely.goBackToPreviousScreen(this._requestId);
     }
 
     private ensureRequestId(): string {
-        if (!this.requestId) {
-            this.requestId = generateRequestId();
+        if (!this._requestId) {
+            this._requestId = generateRequestId();
         }
-        return this.requestId;
+        return this._requestId;
     }
 
     private bindLifecycleEvents(


### PR DESCRIPTION
## Contexte

Suite à la migration v6 iOS (PR base `feat/sdk-v6-migration`), la vue embarquée `<PLYPresentationView>` ne réutilisait **pas** de façon homogène une présentation préchargée :
- **iOS** : matching par `presentation.id` + `placementId`, ou re-load.
- **Android** : **re-preload systématique** dans la vue (jamais de réutilisation).
- **Flutter** (référence) : lookup par `requestId` (`loadedPresentations[requestId]`).

Cette PR aligne RN sur le natif iOS/Android et Flutter : la vue réutilise **exactement** la présentation que la couche JS a déjà préchargée, corrélée par le `requestId` du bridge.

## Changements

- **JS** : `PresentationRequest` expose un getter public `requestId` ; `<PLYPresentationView>` accepte une prop `request` et transmet `request.requestId` au natif.
- **iOS** : prop `requestId` sur `PurchaselyView` → lookup via `+[PurchaselyRN loadedPresentationForRequestId:]` (lit `kPresentationsByRequest`) et réutilise le `controller`. Fallback sur les chemins `placementId`/`presentation` existants.
- **Android** : prop `requestId` sur `PurchaselyViewManager` → réutilise `PurchaselyModule.loadedPresentation(requestId)` via `buildView(...)` au lieu de re-preload. Fallback sur le chemin build+preload existant.

## Contrat

Précharger la requête (`await request.preload()`) **avant** de la passer à la vue ; sinon `requestId` est `null` et la vue retombe sur `placementId`/`presentation`.

```tsx
const request = Purchasely.presentation.placement('ONBOARDING').build()
await request.preload()
<PLYPresentationView request={request} onPresentationClosed={...} />
```

## Vérification

- `yarn typecheck` ✅ · `yarn lint` ✅ · Jest **140/140** (4 nouveaux tests) ✅
- iOS compile (`xcodebuild`) exit 0 ✅
- Android `:react-native-purchasely:compileDebugKotlin` **BUILD SUCCESSFUL** ✅
- ⚠️ Runtime du chemin de réutilisation embarqué **non exercé sur device** (compilation + tests unitaires uniquement).

## Suivi
- Pendant : alignement Flutter (suppression `presentSubscriptions`) — séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)