### PR TITLE
feat: parité commitment Apple (iOS 26.4+) sur le bridge React Native

### DIFF
--- a/MIGRATION-v6.md
+++ b/MIGRATION-v6.md
@@ -548,6 +548,49 @@ outcome's `plan` field), the `type` field is normalized to the numeric
 is needed for this ahead of time — `plan.type` will keep comparing equal to
 the `PlanType` enum members either way.
 
+## Commitment info (Apple-only, iOS 26.4+)
+
+v6 surfaces Apple's **multi-period commitment** plans (e.g. a *monthly
+subscription with a 12-month commitment*) as structured data on the plan and the
+subscription. These fields are **Apple-only**: they are absent on Android and on
+Apple plans / subscriptions without a commitment. They are distinct from the
+`billing_plan_type` / `commitment` / `commitment_progress` **event** strings in
+`PurchaselyEventProperties` (analytics), which are unchanged.
+
+```ts
+import type {
+  PLYCommitmentInfo,
+  PLYCommitmentProgress,
+  PLYBillingPlanType, // 'unspecified' | 'upFront' | 'monthly'
+} from 'react-native-purchasely'
+
+// On a plan (allProducts / planWithIdentifier / outcome.plan /
+// the interceptAction('purchase') payload plan):
+const plan = await Purchasely.planWithIdentifier('monthly-12mo')
+plan.commitmentInfo // PLYCommitmentInfo[] | undefined
+// e.g. [{ billingPlanType: 'monthly', billingPrice: 9.99, billingPeriod: 'P1M',
+//         totalPrice: 119.88, totalPeriod: 'P1Y', totalDuration: 12 }]
+
+// On a subscription (userSubscriptions / userSubscriptionsHistory):
+const [sub] = await Purchasely.userSubscriptions()
+sub.commitmentProgress // PLYCommitmentProgress | null | undefined
+// e.g. { billingPeriodNumber: 3, totalBillingPeriods: 12,
+//        commitmentExpiresDate: '2026-07-20T12:00:00Z', commitmentPrice: 9.99 }
+```
+
+`setDynamicOffering` also accepts an optional `billingPlanType` (Apple-only;
+ignored on Android):
+
+```ts
+Purchasely.setDynamicOffering({
+  reference: 'ref',
+  planVendorId: 'monthly-12mo',
+  billingPlanType: 'monthly', // force the monthly-commitment term on iOS 26.4+
+})
+```
+
+---
+
 ## Need a hand?
 
 Use the Purchasely AI plugin / skills (`purchasely-integrate`,

--- a/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
+++ b/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
@@ -682,7 +682,9 @@ fun decrementUserAttribute(key: String, value: Double, legalBasis: String?) {
   }
 
   @ReactMethod
-  fun setDynamicOffering(reference: String, planVendorId: String, offerId: String?, promise: Promise) {
+  // billingPlanType is Apple-only (iOS 26.4+ commitment) — the Android SDK has no
+  // such option, so the arg is accepted for cross-platform bridge parity and ignored.
+  fun setDynamicOffering(reference: String, planVendorId: String, offerId: String?, billingPlanType: String?, promise: Promise) {
      Purchasely.setDynamicOffering(reference, planVendorId, offerId) {
        promise.resolve(it)
      }

--- a/packages/purchasely/ios/Classes/Hybrid/PLYPlan+Hybrid.h
+++ b/packages/purchasely/ios/Classes/Hybrid/PLYPlan+Hybrid.h
@@ -11,6 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Wire value for `PLYBillingPlanType` shared with JS ('unspecified' / 'upFront' / 'monthly').
+FOUNDATION_EXPORT NSString *PLYBillingPlanTypeToRNString(enum PLYBillingPlanType type);
+/// Inverse of `PLYBillingPlanTypeToRNString`; unknown / nil maps to `PLYBillingPlanTypeUnspecified`.
+FOUNDATION_EXPORT enum PLYBillingPlanType PLYBillingPlanTypeFromRNString(NSString * _Nullable value);
+
 @interface PLYPlan (Hybrid)
 
 - (NSDictionary *)asDictionary;

--- a/packages/purchasely/ios/Classes/Hybrid/PLYPlan+Hybrid.m
+++ b/packages/purchasely/ios/Classes/Hybrid/PLYPlan+Hybrid.m
@@ -7,6 +7,21 @@
 
 #import "PLYPlan+Hybrid.h"
 
+NSString *PLYBillingPlanTypeToRNString(enum PLYBillingPlanType type) {
+    switch (type) {
+        case PLYBillingPlanTypeUpFront: return @"upFront";
+        case PLYBillingPlanTypeMonthly: return @"monthly";
+        case PLYBillingPlanTypeUnspecified:
+        default: return @"unspecified";
+    }
+}
+
+enum PLYBillingPlanType PLYBillingPlanTypeFromRNString(NSString * _Nullable value) {
+    if ([value isEqualToString:@"upFront"]) return PLYBillingPlanTypeUpFront;
+    if ([value isEqualToString:@"monthly"]) return PLYBillingPlanTypeMonthly;
+    return PLYBillingPlanTypeUnspecified;
+}
+
 @implementation PLYPlan (Hybrid)
 
 - (void)isEligibleForIntroductoryOffer:(void (^)(BOOL))completion {
@@ -84,6 +99,23 @@
 	NSString *introPeriod = [self localizedIntroductoryPeriodWithLanguage:nil];
 	if (introPeriod != nil) {
 		[dict setObject:introPeriod forKey:@"introPeriod"];
+	}
+
+	// Apple-only (iOS 26.4+) multi-period commitment installments. Empty on
+	// other stores / non-committed plans, in which case the key is omitted.
+	if (self.commitmentInfo.count > 0) {
+		NSMutableArray<NSDictionary *> *commitments = [NSMutableArray new];
+		for (PLYCommitmentInfo *info in self.commitmentInfo) {
+			[commitments addObject:@{
+				@"billingPlanType": PLYBillingPlanTypeToRNString(info.billingPlanType),
+				@"billingPrice": info.billingPrice,
+				@"billingPeriod": info.billingPeriod,
+				@"totalPrice": info.totalPrice,
+				@"totalPeriod": info.totalPeriod,
+				@"totalDuration": @(info.totalDuration),
+			}];
+		}
+		[dict setObject:commitments forKey:@"commitmentInfo"];
 	}
 
 	return dict;

--- a/packages/purchasely/ios/Classes/Hybrid/PLYSubscription+Hybrid.m
+++ b/packages/purchasely/ios/Classes/Hybrid/PLYSubscription+Hybrid.m
@@ -28,6 +28,18 @@
 		[dict setObject:[dateFormat stringFromDate:self.cancelledDate] forKey:@"cancelledDate"];
 	}
 
+	// Apple-only (iOS 26.4+) progress through a multi-period commitment.
+	// nil on other stores / non-committed subscriptions → key omitted.
+	if (self.commitmentProgress != nil) {
+		PLYCommitmentProgress *progress = self.commitmentProgress;
+		[dict setObject:@{
+			@"billingPeriodNumber": @(progress.billingPeriodNumber),
+			@"totalBillingPeriods": @(progress.totalBillingPeriods),
+			@"commitmentExpiresDate": [dateFormat stringFromDate:progress.commitmentExpiresDate],
+			@"commitmentPrice": progress.commitmentPrice,
+		} forKey:@"commitmentProgress"];
+	}
+
 	return dict;
 }
 

--- a/packages/purchasely/ios/PurchaselyRN.m
+++ b/packages/purchasely/ios/PurchaselyRN.m
@@ -1000,11 +1000,12 @@ RCT_EXPORT_METHOD(userSubscriptionsHistory:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(setDynamicOffering:(NSString *)reference
                   planVendorId:(NSString *)planVendorId
                   offerId:(nullable NSString *)offerId
+                  billingPlanType:(nullable NSString *)billingPlanType
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [Purchasely setDynamicOfferingWithReference:reference planVendorId:planVendorId offerVendorId:offerId billingPlanType:PLYBillingPlanTypeUnspecified completion:^(BOOL result) {
+      [Purchasely setDynamicOfferingWithReference:reference planVendorId:planVendorId offerVendorId:offerId billingPlanType:PLYBillingPlanTypeFromRNString(billingPlanType) completion:^(BOOL result) {
         resolve(@(result));
       }];
     });

--- a/packages/purchasely/src/__tests__/index.test.ts
+++ b/packages/purchasely/src/__tests__/index.test.ts
@@ -628,7 +628,24 @@ describe('Purchasely SDK', () => {
             expect(mockedPurchasely.setDynamicOffering).toHaveBeenCalledWith(
                 'ref-123',
                 'plan-123',
-                'offer-123'
+                'offer-123',
+                'unspecified'
+            )
+        })
+
+        it('should forward the Apple-only billingPlanType when set', async () => {
+            await Purchasely.setDynamicOffering({
+                reference: 'ref-123',
+                planVendorId: 'plan-123',
+                offerVendorId: 'offer-123',
+                billingPlanType: 'monthly',
+            })
+
+            expect(mockedPurchasely.setDynamicOffering).toHaveBeenCalledWith(
+                'ref-123',
+                'plan-123',
+                'offer-123',
+                'monthly'
             )
         })
 

--- a/packages/purchasely/src/__tests__/types.test.ts
+++ b/packages/purchasely/src/__tests__/types.test.ts
@@ -27,7 +27,11 @@ import type {
     PLYPresentationMetadata,
     PurchaselyOffer,
     PurchaselySubscriptionOffer,
+    PLYCommitmentInfo,
+    PLYCommitmentProgress,
+    PLYBillingPlanType,
 } from '../types'
+import type { PLYPurchasePayload } from '../presentationTypes'
 
 import {
     PlanType,
@@ -247,6 +251,137 @@ describe('Purchasely Types', () => {
             }
 
             expect(subscription.cumulatedRevenuesInUSD).toBeUndefined()
+        })
+    })
+
+    // Apple-only (iOS 26.4+) "monthly subscription with 12-month commitment".
+    // Structured data on the plan / subscription — distinct from the
+    // `billing_plan_type` / `commitment` / `commitment_progress` *event* strings
+    // in PurchaselyEventProperties.
+    describe('PLYCommitmentInfo (Apple-only)', () => {
+        const commitmentInfo: PLYCommitmentInfo[] = [
+            {
+                billingPlanType: 'monthly',
+                billingPrice: 9.99,
+                billingPeriod: 'P1M',
+                totalPrice: 119.88,
+                totalPeriod: 'P1Y',
+                totalDuration: 12,
+            },
+        ]
+
+        const committedPlan: PurchaselyPlan = {
+            vendorId: 'monthly-12mo',
+            productId: 'product-123',
+            name: 'Monthly (12-month commitment)',
+            type: PlanType.PLAN_TYPE_AUTO_RENEWING_SUBSCRIPTION,
+            amount: 9.99,
+            localizedAmount: '$9.99',
+            currencyCode: 'USD',
+            currencySymbol: '$',
+            price: '$9.99/month',
+            period: 'P1M',
+            hasIntroductoryPrice: false,
+            introPrice: '',
+            introAmount: 0,
+            introDuration: '',
+            introPeriod: '',
+            hasFreeTrial: false,
+            commitmentInfo,
+        }
+
+        it('exposes structured commitment info on a plan', () => {
+            expect(committedPlan.commitmentInfo).toHaveLength(1)
+            expect(committedPlan.commitmentInfo?.[0]?.billingPlanType).toBe('monthly')
+            expect(committedPlan.commitmentInfo?.[0]?.billingPrice).toBe(9.99)
+            expect(committedPlan.commitmentInfo?.[0]?.totalPrice).toBe(119.88)
+            expect(committedPlan.commitmentInfo?.[0]?.totalPeriod).toBe('P1Y')
+            expect(committedPlan.commitmentInfo?.[0]?.totalDuration).toBe(12)
+        })
+
+        it('is optional (absent on Android and non-committed Apple plans)', () => {
+            const plainPlan: PurchaselyPlan = {
+                ...committedPlan,
+                commitmentInfo: undefined,
+            }
+            expect(plainPlan.commitmentInfo).toBeUndefined()
+        })
+
+        it('accepts every billing plan type', () => {
+            const types: PLYBillingPlanType[] = [
+                'unspecified',
+                'upFront',
+                'monthly',
+            ]
+            expect(types).toHaveLength(3)
+        })
+
+        it('carries commitmentInfo on the interceptAction purchase payload plan', () => {
+            const payload: PLYPurchasePayload = {
+                kind: 'purchase',
+                plan: committedPlan,
+            }
+            expect(payload.plan.commitmentInfo?.[0]?.totalDuration).toBe(12)
+        })
+    })
+
+    describe('PLYCommitmentProgress (Apple-only)', () => {
+        const baseSubscription: PurchaselySubscription = {
+            purchaseToken: 'token-123',
+            subscriptionSource: SubscriptionSource.APPLE_APP_STORE,
+            nextRenewalDate: '2026-08-20T12:00:00Z',
+            cancelledDate: '',
+            plan: {
+                vendorId: 'monthly-12mo',
+                productId: 'premium-product',
+                name: 'Monthly',
+                type: PlanType.PLAN_TYPE_AUTO_RENEWING_SUBSCRIPTION,
+                amount: 9.99,
+                localizedAmount: '$9.99',
+                currencyCode: 'USD',
+                currencySymbol: '$',
+                price: '$9.99/month',
+                period: 'P1M',
+                hasIntroductoryPrice: false,
+                introPrice: '',
+                introAmount: 0,
+                introDuration: '',
+                introPeriod: '',
+                hasFreeTrial: false,
+            },
+            product: {
+                name: 'Premium',
+                vendorId: 'premium-product',
+                plans: [],
+            },
+        }
+
+        it('exposes commitment progress on a subscription', () => {
+            const commitmentProgress: PLYCommitmentProgress = {
+                billingPeriodNumber: 3,
+                totalBillingPeriods: 12,
+                commitmentExpiresDate: '2026-07-20T12:00:00Z',
+                commitmentPrice: 9.99,
+            }
+            const subscription: PurchaselySubscription = {
+                ...baseSubscription,
+                commitmentProgress,
+            }
+            expect(subscription.commitmentProgress?.billingPeriodNumber).toBe(3)
+            expect(subscription.commitmentProgress?.totalBillingPeriods).toBe(12)
+            expect(subscription.commitmentProgress?.commitmentExpiresDate).toBe(
+                '2026-07-20T12:00:00Z'
+            )
+            expect(subscription.commitmentProgress?.commitmentPrice).toBe(9.99)
+        })
+
+        it('is optional / nullable (absent on Android and non-committed subs)', () => {
+            expect(baseSubscription.commitmentProgress).toBeUndefined()
+            const nulled: PurchaselySubscription = {
+                ...baseSubscription,
+                commitmentProgress: null,
+            }
+            expect(nulled.commitmentProgress).toBeNull()
         })
     })
 

--- a/packages/purchasely/src/index.ts
+++ b/packages/purchasely/src/index.ts
@@ -417,7 +417,12 @@ const getBuiltInAttribute = (key: string): Promise<any> => {
 };
 
 const setDynamicOffering = (offering: DynamicOffering): Promise<boolean> => {
-  return NativeModules.Purchasely.setDynamicOffering(offering.reference, offering.planVendorId, offering.offerVendorId);
+  return NativeModules.Purchasely.setDynamicOffering(
+    offering.reference,
+    offering.planVendorId,
+    offering.offerVendorId,
+    offering.billingPlanType ?? 'unspecified'
+  );
 };
 
 const getDynamicOfferings = (): Promise<DynamicOffering[]> => {

--- a/packages/purchasely/src/interfaces.ts
+++ b/packages/purchasely/src/interfaces.ts
@@ -1,4 +1,5 @@
 import type { PLYDataProcessingLegalBasis } from './enums';
+import type { PLYBillingPlanType } from './types';
 
 export interface Constants {
   logLevelDebug: number;
@@ -92,4 +93,9 @@ export interface DynamicOffering {
   reference: string;
   planVendorId: string;
   offerVendorId?: string | null;
+  /**
+   * Billing plan type to force for this offering. Apple-only (iOS 26.4+);
+   * ignored on Android. Defaults to `'unspecified'` (native picks the default).
+   */
+  billingPlanType?: PLYBillingPlanType | null;
 }

--- a/packages/purchasely/src/presentationTypes.ts
+++ b/packages/purchasely/src/presentationTypes.ts
@@ -174,6 +174,10 @@ export interface PLYNavigatePayload {
 /** Typed payload for the purchase action. */
 export interface PLYPurchasePayload {
     kind: 'purchase';
+    /**
+     * Plan being purchased. On Apple (iOS 26.4+) with a multi-period commitment
+     * this carries `plan.commitmentInfo` (see {@link PurchaselyPlan}).
+     */
     plan: PurchaselyPlan;
     subscriptionOffer?: PurchaselySubscriptionOffer | null;
     offer?: PurchaselyOffer | null;

--- a/packages/purchasely/src/types.ts
+++ b/packages/purchasely/src/types.ts
@@ -8,6 +8,48 @@ import {
   PLYDataProcessingLegalBasis
 } from './enums';
 
+/**
+ * Billing plan of a commitment installment. Apple-only (iOS 26.4+).
+ * Mirrors the native `PLYBillingPlanType` façade.
+ */
+export type PLYBillingPlanType = 'unspecified' | 'upFront' | 'monthly';
+
+/**
+ * Billing information for a subscription with a multi-period commitment
+ * (Apple-only, iOS 26.4+ "monthly subscription with 12-month commitment").
+ * Mirrors the native `PLYCommitmentInfo`. Empty/absent on Android and on Apple
+ * plans without a commitment.
+ */
+export type PLYCommitmentInfo = {
+  billingPlanType: PLYBillingPlanType;
+  /** Per-billing-cycle price (e.g. 9.99 for a monthly billed plan). */
+  billingPrice: number;
+  /** ISO 8601 duration of each billing cycle, e.g. 'P1M'. */
+  billingPeriod: string;
+  /** Total price over the full commitment period (e.g. 119.88 for 12 x 9.99). */
+  totalPrice: number;
+  /** ISO 8601 duration of the full commitment, e.g. 'P1Y'. */
+  totalPeriod: string;
+  /** Number of billing cycles in the commitment (1 for upFront, 12 for 12-month monthly). */
+  totalDuration: number;
+};
+
+/**
+ * A subscriber's progress through a multi-period commitment (Apple-only,
+ * iOS 26.4+). Mirrors the native `PLYCommitmentProgress`. `null`/absent on
+ * Android and on subscriptions without a commitment.
+ */
+export type PLYCommitmentProgress = {
+  /** Current billing period number within the commitment (1-based). */
+  billingPeriodNumber: number;
+  /** Total number of billing periods in the commitment. */
+  totalBillingPeriods: number;
+  /** Date when the commitment expires, ISO 8601. */
+  commitmentExpiresDate: string;
+  /** Price charged for this billing period. */
+  commitmentPrice: number;
+};
+
 export type PurchaselyPlan = {
   vendorId: string;
   productId: string;
@@ -25,6 +67,11 @@ export type PurchaselyPlan = {
   introDuration: string;
   introPeriod: string;
   hasFreeTrial: boolean;
+  /**
+   * Commitment installment details (Apple-only, iOS 26.4+). Absent on Android
+   * and on plans without a multi-period commitment.
+   */
+  commitmentInfo?: PLYCommitmentInfo[];
 };
 
 export type PurchaselyOffer = {
@@ -83,6 +130,11 @@ export type PurchaselySubscription = {
   subscriptionDurationInWeeks?: number;
   /** Android-only — see {@link cumulatedRevenuesInUSD}. */
   subscriptionDurationInMonths?: number;
+  /**
+   * Progress through a multi-period commitment (Apple-only, iOS 26.4+).
+   * `null`/absent on Android and on subscriptions without a commitment.
+   */
+  commitmentProgress?: PLYCommitmentProgress | null;
 };
 
 export type PurchaselyEventsNames =


### PR DESCRIPTION
## Contexte

Le SDK iOS natif Purchasely v6 (pod `Purchasely 6.0.0-rc.3`) expose le support Apple **« monthly subscription with 12-month commitment »** (iOS 26.4+) via une API publique (`PLYPlan.commitmentInfo`, `PLYSubscription.commitmentProgress`, `PLYBillingPlanType`). Le bridge React Native ne l'exposait pas encore. Cette PR comble ce trou de parité côté React Native uniquement.

Fonctionnalité **Apple-only** : les champs restent absents/null côté Android.

## Fichiers modifiés

**JS / TypeScript**
- `packages/purchasely/src/types.ts` : nouveaux types `PLYBillingPlanType` (union `'unspecified' | 'upFront' | 'monthly'`), `PLYCommitmentInfo`, `PLYCommitmentProgress` ; champs `PurchaselyPlan.commitmentInfo?` et `PurchaselySubscription.commitmentProgress?`.
- `packages/purchasely/src/presentationTypes.ts` : note JSDoc sur `PLYPurchasePayload.plan` (porte déjà `commitmentInfo` via le type `PurchaselyPlan` réutilisé — pas de champ dupliqué).
- `packages/purchasely/src/interfaces.ts` : `DynamicOffering.billingPlanType?` (Apple-only).
- `packages/purchasely/src/index.ts` : `setDynamicOffering` transmet `billingPlanType` (défaut `'unspecified'`).

**iOS (bridge ObjC)**
- `PLYPlan+Hybrid.{h,m}` : helpers `PLYBillingPlanTypeToRNString` / `FromRNString` + sérialisation de `commitmentInfo` dans `asDictionary` (couvre `allProducts`, `planWithIdentifier`, `outcome.plan` et le payload purchase de l'interceptor, qui passent tous par `PLYPlan.asDictionary`).
- `PLYSubscription+Hybrid.m` : sérialisation de `commitmentProgress` (`userSubscriptions` / `userSubscriptionsHistory`), dates en ISO 8601.
- `PurchaselyRN.m` : `setDynamicOffering` accepte `billingPlanType` et le mappe vers l'enum natif.

**Android**
- `PurchaselyModule.kt` : `setDynamicOffering` accepte le 4e argument `billingPlanType` (parité du nombre d'args du bridge RN) et l'ignore — le SDK Android n'a pas cette option (Apple-only). Le mapping plan/subscription existant (`toMap()`) est null-safe et inchangé.

**Docs / Tests**
- `MIGRATION-v6.md` : section « Commitment info (Apple-only, iOS 26.4+) ».
- `__tests__/types.test.ts` : tests d'exposition (plan, subscription, payload purchase, union). `__tests__/index.test.ts` : assertion `setDynamicOffering` mise à jour + cas `billingPlanType`.

## Payloads exacts exposés (JS)

Plan (`commitmentInfo` présent uniquement si non vide côté iOS) :
```json
"commitmentInfo": [{
  "billingPlanType": "monthly",
  "billingPrice": 9.99, "billingPeriod": "P1M",
  "totalPrice": 119.88, "totalPeriod": "P1Y", "totalDuration": 12
}]
```

Subscription (`commitmentProgress` présent uniquement si non nil) :
```json
"commitmentProgress": {
  "billingPeriodNumber": 3, "totalBillingPeriods": 12,
  "commitmentExpiresDate": "2026-07-20T12:00:00+0000", "commitmentPrice": 9.99
}
```

Payload purchase de `interceptAction('purchase')` : `{ kind: 'purchase', plan: { …, commitmentInfo: [...] }, … }` — `commitmentInfo` porté par `plan` (type `PurchaselyPlan`).

## Convention wire `billingPlanType` (intentionnel)

Côté RN, `billingPlanType` est sérialisé en **string camelCase** (`'unspecified' | 'upFront' | 'monthly'`), pas en entier. Choix délibéré : cohérent avec les unions de string du reste de la surface v6 (`PLYCloseReason`, `PLYPurchaseResult`…) et auto-descriptif dans un bridge cross-platform. La convention wire par-bridge peut différer d'un SDK à l'autre (décision validée).

Note fidélité : `commitmentProgress` inclut `commitmentPrice` — présent dans l'API réelle `PLYCommitmentProgress` du pod (sérialisation fidèle).

## Résultats

| Vérification | Résultat |
|---|---|
| `yarn test` | **212 passed / 212** (6 suites ; baseline 205 + 7 nouveaux tests) |
| `yarn typecheck` | **0 erreur** |
| `yarn lint` | **0 erreur** (5 warnings pré-existants dans `coverage/` généré, hors périmètre) |

## Build iOS local

Commande (workspace CocoaPods, jamais le `.xcodeproj`) :
```
pod install   # dans example/ios (offline, pod Purchasely 6.0.0-rc.3 déjà en cache)
xcodebuild -workspace example/ios/example.xcworkspace -scheme example \
  -configuration Debug -sdk iphonesimulator \
  -destination 'generic/platform=iOS Simulator' \
  -derivedDataPath example/ios/DerivedData CODE_SIGNING_ALLOWED=NO build
```

- **Mon mapping ObjC compile contre le pod 6.0.0-rc.3 : PROUVÉ.** `PLYPlan+Hybrid.m`, `PLYSubscription+Hybrid.m` et `PurchaselyRN.m` compilent en `.o` (arm64 + x86_64) sans erreur, et le scheme **`Pods-example` build SUCCEEDED** (tous les pods, dont `react-native-purchasely`, compilent et s'archivent).
- Le scheme `example` (app complète) échoue **uniquement à l'édition de liens finale** du binaire, sur des symboles C++ **react-native-screens / React-Fabric (New Architecture)** non résolus (`facebook::react::Sealable`, `ShadowNode::getDebugName()`…). Aucun symbole commitment/Purchasely dans la liste. Échec **environnemental / pré-existant, sans rapport avec ce diff** (aucun fichier RNScreens/Fabric/Podfile/example touché).

## Couverture CI iOS

iOS **est couvert** par la CI :
- `.github/workflows/ci.yml` → job **`build-ios`** (macos-latest) : `pod install --repo-update`, prebuild `Pods-example`, puis build du scheme `example` (Debug). Se déclenche sur toutes les PR.
- `.github/workflows/e2e-ios.yml` → **E2E iOS T1-T20** sur simulateur (macos-15), déclenché sur PR touchant `packages/purchasely/ios/**` / `src/**` (le cas ici).

La CI, contrairement au build local, cible `generic/platform=iOS` avec l'étape de prebuild `Pods-example` — configuration où le problème de liens RNScreens ne se manifeste pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
