### PR TITLE
fix(ios): Swift header not found under Xcode 26 explicit modules

### DIFF
--- a/packages/purchasely/ios/PurchaselyRN.m
+++ b/packages/purchasely/ios/PurchaselyRN.m
@@ -22,7 +22,11 @@
 // the iOS build/E2E CI jobs). If a custom target label ever changes the module
 // name, this single line fails with a "file not found" error naming this exact
 // header, localizing the fix.
+#if __has_include(<react_native_purchasely/react_native_purchasely-Swift.h>)
+#import <react_native_purchasely/react_native_purchasely-Swift.h>
+#else
 #import "react_native_purchasely-Swift.h"
+#endif
 
 #pragma mark - event names
 


### PR DESCRIPTION
## Problem

Building an app that depends on `react-native-purchasely` (6.0.0) under **Xcode 26**, with the default "Explicitly Built Modules" build setting, fails with:

```
'react_native_purchasely-Swift.h' file not found
```

pointing at `PurchaselyRN.m`'s `#import "react_native_purchasely-Swift.h"`.

## Root cause

`PurchaselyRN.m` mixes Objective-C and Swift sources in the same CocoaPods target (it imports the compiler-generated Swift interface header to use `PLYTransitionFactory`, defined in `PLYTransitionFactory.swift`). The import is a plain, quoted `#import "..."`.

Under Xcode 26's explicit module builds, Clang's dependency scanner doesn't treat a quoted, non-modular `#import` as an edge to the pod's own module — so it has no guarantee that this target's Swift compilation (which emits the generated header) has run before the ObjC file is scanned/compiled. The header sometimes doesn't exist yet when the ObjC file needs it.

## Fix

Prefer the angle-bracket, module-qualified form of the import (`<react_native_purchasely/react_native_purchasely-Swift.h>`), guarded with `__has_include` so it falls back to the original quoted import wherever the module path isn't available (older Xcode, non-explicit-modules builds, etc.):

```objc
#if __has_include(<react_native_purchasely/react_native_purchasely-Swift.h>)
#import <react_native_purchasely/react_native_purchasely-Swift.h>
#else
#import "react_native_purchasely-Swift.h"
#endif
```

The module-qualified form lets Clang's explicit-module scanner resolve it as a real dependency on the `react_native_purchasely` module, so the Swift compile is correctly ordered before this file.

## Testing

Verified with a real `bun run ios` (Expo / React Native 0.85, Xcode 26) build, install, and app launch on iOS Simulator — fails with the exact error above without this change, succeeds with it. No Podfile-level workaround (e.g. disabling `SWIFT_ENABLE_EXPLICIT_MODULES`/`CLANG_ENABLE_EXPLICIT_MODULES` for the pod target) was needed once this import is fixed.
