### PR TITLE
fix(deps): bump brace-expansion to >=1.1.16 (CVE-2026-13149)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.29.7",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "basic-ftp": ">=5.3.1",
-    "brace-expansion": "~1.1.13",
+    "brace-expansion": "~1.1.16",
     "cacache/glob": "^10.5.0",
     "fast-xml-builder": ">=1.1.7",
     "flatted": ">=3.4.2",

--- a/test-projects/expo-purchasely-test/package-lock.json
+++ b/test-projects/expo-purchasely-test/package-lock.json
@@ -3454,9 +3454,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/test-projects/expo-purchasely-test/package.json
+++ b/test-projects/expo-purchasely-test/package.json
@@ -26,7 +26,7 @@
   "overrides": {
     "@isaacs/brace-expansion": ">=5.0.1",
     "@xmldom/xmldom": ">=0.9.10",
-    "brace-expansion": "~1.1.13",
+    "brace-expansion": "~1.1.16",
     "fast-uri": ">=4.1.1",
     "fast-xml-parser": ">=5.7.0",
     "flatted": ">=3.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,13 +4633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:~1.1.13":
-  version: 1.1.14
-  resolution: "brace-expansion@npm:1.1.14"
+"brace-expansion@npm:~1.1.16":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
-  checksum: 2de747a5891ea0d3a1946ea1ae26e056a47f7ea8d42a3009e1736ec3a31a5aa69a3c5da59d998426773553afe4c258e5b12d7953b534fa7f2cf12ce92eed4931
+  checksum: aa84023a4118f9185b6f8c71ca3467c945878b141ba340261de209676442f81b08db5b7c7c119707cdecb7322fcfcdb71d8ffea55db9d1aad673d7c65469211f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves the two open **CVE-2026-13149** alerts for `brace-expansion < 1.1.16`.

Both lockfiles deliberately pin brace-expansion to the **1.x line** (the root `minimatch: ~3.1.3` resolution needs it), and both pinned `~1.1.13`, which resolved to the vulnerable **1.1.14**. This bumps the pin to `~1.1.16` so the 1.x line is preserved while moving past the affected range.

| Manifest | Constraint | Resolved |
|---|---|---|
| `package.json` (`resolutions`) | `~1.1.13` → `~1.1.16` | 1.1.14 → **1.1.18** |
| `test-projects/expo-purchasely-test` (`overrides`) | `~1.1.13` → `~1.1.16` | 1.1.14 → **1.1.18** |

`test-projects/rn-purchasely-test` already overrides brace-expansion to `^5.0.5` (resolved 5.0.7), which is outside the `< 1.1.16` affected range, so it is left untouched.

## Test plan

- [x] `yarn install` — lockfile resolves cleanly, brace-expansion at 1.1.18
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test --maxWorkers=2` — 249/249 passing
- [x] `npm install --package-lock-only --force` (expo) — only the brace-expansion entry changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)