### PR TITLE
fix(deps): bump js-yaml to >=4.3.0 (CVE-2026-59869)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "handlebars": ">=4.7.9",
     "ip-address": ">=10.1.1",
     "joi": "^17.13.4",
-    "js-yaml": ">=4.2.0",
+    "js-yaml": ">=4.3.0",
     "lodash": ">=4.18.0",
     "lodash-es": ">=4.18.0",
     "minimatch": "~3.1.3",

--- a/test-projects/expo-purchasely-test/package-lock.json
+++ b/test-projects/expo-purchasely-test/package-lock.json
@@ -5338,9 +5338,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/test-projects/expo-purchasely-test/package.json
+++ b/test-projects/expo-purchasely-test/package.json
@@ -30,6 +30,7 @@
     "fast-uri": ">=4.1.1",
     "fast-xml-parser": ">=5.7.0",
     "flatted": ">=3.3.4",
+    "js-yaml": ">=4.3.0 <5",
     "minimatch": ">=3.1.3",
     "node-forge": ">=1.4.0",
     "postcss": ">=8.5.10",

--- a/test-projects/rn-purchasely-test/package-lock.json
+++ b/test-projects/rn-purchasely-test/package-lock.json
@@ -6588,6 +6588,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -8427,9 +8428,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "devOptional": true,
             "funding": [
                 {
@@ -11704,7 +11705,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/test-projects/rn-purchasely-test/package.json
+++ b/test-projects/rn-purchasely-test/package.json
@@ -45,6 +45,10 @@
         "fast-xml-builder": ">=1.1.7",
         "fast-xml-parser": ">=5.7.0",
         "flatted": ">=3.3.4",
+        "js-yaml": ">=4.3.0 <5",
+        "@istanbuljs/load-nyc-config": {
+            "js-yaml": "^3.13.1"
+        },
         "lodash": ">=4.18.0",
         "minimatch": ">=3.1.3"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9064,14 +9064,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:>=4.2.0":
-  version: 5.1.0
-  resolution: "js-yaml@npm:5.1.0"
+"js-yaml@npm:>=4.3.0":
+  version: 5.3.0
+  resolution: "js-yaml@npm:5.3.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.mjs
-  checksum: ed920d295619d5a79dc97cf6a83e6be6aa7c23d60eacfd349da1df43c31feaaee9d3630742d59ca230c3d574083989bd397fe8d60d5ddf503e80b54c8cdd35ee
+  checksum: 7b2f946dab72b05ac0fa4b40daa6230044df06fa7a8a8c75944f4e7f644914960fc2f01e7a98d714d986126418cafab1b1b495fbad74f211df49e4818808db55
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves the two open **CVE-2026-59869** alerts for `js-yaml >=4.0.0, <4.3.0`. Both test-project lockfiles resolved the vulnerable **4.2.0**.

| Manifest | Change | Resolved |
|---|---|---|
| `test-projects/rn-purchasely-test` (`overrides`) | + `js-yaml: >=4.3.0 <5` | 4.2.0 → **4.3.1** |
| `test-projects/expo-purchasely-test` (`overrides`) | + `js-yaml: >=4.3.0 <5` | 4.2.0 → **4.3.1** |
| `package.json` (`resolutions`) | `>=4.2.0` → `>=4.3.0` | 5.1.0 → **5.3.0** |

### Why `<5` and not just `>=4.3.0`

Every requester in both projects asks for `^4.1.0` (`eslint`, `@eslint/eslintrc`, `cosmiconfig`, `@expo/xcpretty`). An open-ended `>=4.3.0` resolves to **5.3.0**, i.e. a major bump for all of them. Since 4.3.1 is the patched release on the 4.x line, capping at `<5` clears the advisory without taking a major upgrade as a side effect of a security patch.

### Why the nested override in the rn project

`@istanbuljs/load-nyc-config` depends on `js-yaml@^3.13.1` and resolves **3.15.0**, which is *outside* the affected range — but it calls `yaml.safeLoad()`, an API js-yaml 4 removed. A blanket `js-yaml` override would have force-upgraded it and broken nyc coverage, so it is explicitly pinned back:

```json
"js-yaml": ">=4.3.0 <5",
"@istanbuljs/load-nyc-config": {
    "js-yaml": "^3.13.1"
}
```

Verified in the regenerated lockfile — top-level js-yaml is 4.3.1 while `@istanbuljs/load-nyc-config/node_modules/js-yaml` stays at 3.15.0.

### Root note

Root had **no open alert** — its `>=4.2.0` resolution already pulled a safe 5.1.0. The floor itself named a vulnerable version though, so it is tightened to `>=4.3.0` for hygiene. Root stays on the 5.x line it already ran.

## Test plan

- [x] `yarn install` — lockfile resolves cleanly, root js-yaml at 5.3.0
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test --maxWorkers=2` — 249/249 passing
- [x] `npm ci --dry-run` (rn) — lockfile/manifest in sync, 861 packages resolve
- [x] Verified `@istanbuljs/load-nyc-config` still resolves js-yaml 3.15.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)