### PR TITLE
fix(ci): stop caching the generated example/ios/Pods tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,24 +111,31 @@ jobs:
       - name: Build library
         run: yarn prepare
 
+      # Only the content-addressed CocoaPods download caches are cached here.
+      # `example/ios/Pods` (the *generated* install tree) is deliberately NOT
+      # cached: a restore-key hit could hand a stale tree to `pod install`,
+      # which does not fully reconcile it, and the example app then compiled
+      # against stale React Native headers while linking the current prebuilt
+      # React.xcframework -- surfacing as missing `facebook::react::*` vtables
+      # in libRNScreens.a at link time.
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
           path: |
-            example/ios/Pods
             ~/.cocoapods
             ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec') }}
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 
+      # Exact-match only (no restore-keys): a partial hit would mix object
+      # files built against a different Pods install, the same staleness class
+      # of failure described above.
       - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
           path: example/ios/DerivedData
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'example/ios/*.xcodeproj/project.pbxproj') }}
-          restore-keys: |
-            ${{ runner.os }}-derived-data-
+          key: ${{ runner.os }}-derived-data-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'example/ios/*.xcodeproj/project.pbxproj', 'yarn.lock') }}
 
       - name: Install CocoaPods
         run: |
@@ -175,14 +182,15 @@ jobs:
       - name: Build library
         run: yarn prepare
 
+      # See the note in build-ios: only the content-addressed download caches
+      # are cached, never the generated `example/ios/Pods` tree.
       - name: Cache CocoaPods
         uses: actions/cache@v4
         with:
           path: |
-            example/ios/Pods
             ~/.cocoapods
             ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec') }}
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 


### PR DESCRIPTION
## Summary

`build-ios` has failed on **every** PR since late July — including PRs that only touch a test-project lockfile. The failure is the CI cache, not the app code.

```
"typeinfo for facebook::react::YogaStylableProps", referenced from ...
"vtable for facebook::react::DebugStringConvertible", referenced from
    ... in libRNScreens.a(RNSFullWindowOverlay.o)
ld: symbol(s) not found for architecture arm64
```

## Root cause

The CocoaPods cache included `example/ios/Pods` — the **generated** install tree — behind a loose `restore-keys: ${{ runner.os }}-cocoapods-` fallback. The v6 migration (#243, merged 2026-07-24) changed the Podfile/podspec hash, so the exact key has never matched since. Every run therefore restores a **pre-v6 Pods tree**. From the failing run's log:

```
key:      macOS-cocoapods-21c48bdc...   (requested)
restored: macOS-cocoapods-a2f4547b...   (stale, different key)
```

`pod install` does not fully reconcile a stale tree. RNScreens then compiled against **stale React Native headers** while linking the **current** prebuilt `React.xcframework` — a header/binary mismatch that surfaces as those missing `facebook::react::*` vtables.

The timeline matches exactly: `build-ios` passed through 2026-07-25 and has failed on every run since, across unrelated branches.

## Verification

On this same commit, with a clean `pod install` and the exact CI `xcodebuild` invocation:

```
** BUILD SUCCEEDED **
```

Same prebuilt core, same Xcode 26. **Only the stale cache distinguishes CI from a working build.** As a control, a *stale* local Pods tree failed too — with a different stale-artifact error (`Build input file cannot be found: RCTConvert_PurchaselyRN.m`, a file the v6 reorg removed), independently showing that a stale Pods tree survives `pod install` and breaks the build.

## Fix

- **Cache only `~/.cocoapods` and `~/Library/Caches/CocoaPods`.** These are content-addressed download caches, so a restore-key hit is safe and still avoids re-downloading pods. The Pods tree is regenerated each run (~20s locally).
- **Add `yarn.lock` to both cache keys** so a React Native version bump invalidates them.
- **Drop the DerivedData `restore-keys`** so it is exact-match only. A partial hit would mix object files built against a different Pods install — the same staleness class of bug. It was latent here (that cache was cold in the failing run), but it is the same footgun.

Applied to both jobs that install the example Pods: `build-ios` and `ios-unit-tests`.

## Note on what this does *not* change

No app, Podfile, or dependency changes — the diff is workflow-only. That is deliberate: if `build-ios` goes green here, it confirms the diagnosis, since nothing but the cache behaviour changed.

Unrelated and left alone: #278 fixes a *different* iOS problem (a Swift header **compile** error under Xcode 26 explicit modules); it does not address this **link** failure.

## Test plan

- [x] Clean `pod install` + CI's exact `xcodebuild` command locally — `** BUILD SUCCEEDED **`
- [x] Confirmed the failing CI run restored a stale cache under a different key
- [x] Confirmed DerivedData cache was cold in the failing run (so Pods is the culprit)
- [x] `ruby -ryaml` parses the workflow; all 7 jobs still present
- [ ] `build-ios` green in CI on this PR (the real test)
- [ ] `iOS Unit Tests (bridge)` still green with the narrowed cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)