### PR TITLE
feat(commitment): surface billingPlanType across the bridge

### DIFF
--- a/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
+++ b/packages/purchasely/android/src/main/java/com/reactnativepurchasely/PurchaselyModule.kt
@@ -1236,6 +1236,10 @@ fun decrementUserAttribute(key: String, value: Double, legalBasis: String?) {
             transformPlanToMap(plan).toMutableMap()
           )
         )
+        // Apple-only (iOS 26.4+ commitment); Google Play has no equivalent, so
+        // this is always "unspecified" here. Emitted for bridge parity so JS
+        // reads the same key shape on both platforms.
+        payload.putString("billingPlanType", "unspecified")
         offer?.let {
           val offerMap = Arguments.createMap()
           it.vendorId?.let { v -> offerMap.putString("vendorId", v) }
@@ -1398,7 +1402,12 @@ fun decrementUserAttribute(key: String, value: Double, legalBasis: String?) {
         Pair("storeOfferId", storeOfferId),
         Pair("offerId", storeOfferId),
         Pair("offerVendorId", offerVendorId),
-        Pair("default", default)
+        Pair("default", default),
+        // billingPlanType is Apple-only (iOS 26.4+ commitment) — Google Play has
+        // no commitment concept, so the Android SDK exposes nothing to map here.
+        // Emitted as "unspecified" for bridge parity, matching the ignored
+        // `billingPlanType` on setDynamicOffering/getDynamicOfferings.
+        Pair("billingPlanType", "unspecified")
       )
     }
 

--- a/packages/purchasely/ios/Classes/Hybrid/PLYPresentationPlan+Hybrid.m
+++ b/packages/purchasely/ios/Classes/Hybrid/PLYPresentationPlan+Hybrid.m
@@ -6,6 +6,7 @@
 //
 
 #import "PLYPresentationPlan+Hybrid.h"
+#import "PLYPlan+Hybrid.h"
 #import <Foundation/Foundation.h>
 
 @implementation PLYPresentationPlan (Hybrid)
@@ -32,7 +33,14 @@
     // `default` is an ObjC keyword; the v6 SDK exposes the property as
     // `default_` (getter `default`), so dot-syntax must use `default_`.
     [dict setObject:@(self.default_) forKey:@"default"];
-    
+
+    // Backend-resolved `commitment_billing_type`. Always emitted (never nil —
+    // the native enum defaults to `.unspecified` when the key is absent from
+    // the paywall JSON) so JS can tell a monthly-billing commitment plan from
+    // a plain one without inspecting `PLYPlan.commitmentInfo`.
+    [dict setObject:PLYBillingPlanTypeToRNString(self.billingPlanType)
+             forKey:@"billingPlanType"];
+
     return dict;
 }
 

--- a/packages/purchasely/ios/PurchaselyRN.m
+++ b/packages/purchasely/ios/PurchaselyRN.m
@@ -1870,6 +1870,14 @@ RCT_EXPORT_METHOD(registerActionInterceptor:(NSString *)kind) {
                         if (params.plan != nil) {
                             payloadOut[@"plan"] = [params.plan asDictionary];
                         }
+                        // Billing plan the paywall resolved for this purchase.
+                        // `notHandled` lets the native SDK apply it itself; an
+                        // app that handles the purchase and returns `success`
+                        // needs this to know a monthly-billing commitment was
+                        // intended, since `purchaseWithPlanVendorId` has no way
+                        // to carry it (no such native overload in iOS 6.0.0).
+                        payloadOut[@"billingPlanType"] =
+                            PLYBillingPlanTypeToRNString(params.billingPlanType);
                         if (params.promoOffer != nil) {
                             NSMutableDictionary *offer = [NSMutableDictionary new];
                             if (params.promoOffer.vendorId != nil) {

--- a/packages/purchasely/src/__tests__/presentation.integration.test.ts
+++ b/packages/purchasely/src/__tests__/presentation.integration.test.ts
@@ -1085,6 +1085,51 @@ describe('façade · integration with native bridge', () => {
             expect(native.completeActionInterceptor).toHaveBeenCalledWith('cb-1', 'success');
         });
 
+        it('forwards the Apple commitment billingPlanType on the purchase payload', async () => {
+            const handler = jest.fn().mockResolvedValue('notHandled' as const);
+            interceptAction('purchase', handler);
+
+            emit(PURCHASELY_PRESENTATION_EVENTS.ACTION_INTERCEPTED, {
+                requestId: 'req-commitment',
+                callbackId: 'cb-commitment',
+                kind: 'purchase',
+                info: {},
+                payload: {
+                    plan: { vendorId: 'annual-billed-monthly' },
+                    billingPlanType: 'monthly',
+                },
+            });
+
+            await new Promise((r) => setImmediate(r));
+
+            const [, payload] = handler.mock.calls[0];
+            expect(payload).toMatchObject({
+                kind: 'purchase',
+                billingPlanType: 'monthly',
+            });
+        });
+
+        it("defaults billingPlanType to 'unspecified' when native omits it", async () => {
+            const handler = jest.fn().mockResolvedValue('notHandled' as const);
+            interceptAction('purchase', handler);
+
+            emit(PURCHASELY_PRESENTATION_EVENTS.ACTION_INTERCEPTED, {
+                requestId: 'req-no-commitment',
+                callbackId: 'cb-no-commitment',
+                kind: 'purchase',
+                info: {},
+                payload: { plan: { vendorId: 'plain-annual' } },
+            });
+
+            await new Promise((r) => setImmediate(r));
+
+            const [, payload] = handler.mock.calls[0];
+            expect(payload?.kind).toBe('purchase');
+            expect(
+                payload?.kind === 'purchase' ? payload.billingPlanType : null
+            ).toBe('unspecified');
+        });
+
         it('does not auto-resolve orphan events (native must time out)', async () => {
             // No JS interceptor registered for 'restore' — when the native
             // bridge emits the event nobody filters it in, so the bridge layer

--- a/packages/purchasely/src/__tests__/types.test.ts
+++ b/packages/purchasely/src/__tests__/types.test.ts
@@ -356,6 +356,15 @@ describe('Purchasely Types', () => {
             }
             expect(payload.plan.commitmentInfo?.[0]?.totalDuration).toBe(12)
         })
+
+        it('carries the resolved billingPlanType on the purchase payload', () => {
+            const payload: PLYPurchasePayload = {
+                kind: 'purchase',
+                plan: committedPlan,
+                billingPlanType: 'monthly',
+            }
+            expect(payload.billingPlanType).toBe('monthly')
+        })
     })
 
     describe('PLYCommitmentProgress (Apple-only)', () => {
@@ -565,6 +574,16 @@ describe('Purchasely Types', () => {
             }
 
             expect(plan.planVendorId).toBeNull()
+        })
+
+        it('should carry the commitment billingPlanType resolved by the paywall', () => {
+            const plan: PLYPresentationPlan = {
+                planVendorId: 'annual-billed-monthly',
+                storeProductId: 'store-product-123',
+                billingPlanType: 'monthly',
+            }
+
+            expect(plan.billingPlanType).toBe('monthly')
         })
     })
 

--- a/packages/purchasely/src/interceptor.ts
+++ b/packages/purchasely/src/interceptor.ts
@@ -93,6 +93,9 @@ function normalizePayload(
                 plan: normalizePlan(raw.plan),
                 subscriptionOffer: raw.subscriptionOffer ?? null,
                 offer: raw.offer ?? null,
+                // Both bridges always emit this key; the fallback keeps the
+                // field meaningful against an older native build that doesn't.
+                billingPlanType: raw.billingPlanType ?? 'unspecified',
             };
         case 'close':
         case 'closeAll':

--- a/packages/purchasely/src/presentationTypes.ts
+++ b/packages/purchasely/src/presentationTypes.ts
@@ -14,6 +14,7 @@ import type {
     PLYWebCheckoutProvider,
 } from './enums';
 import type {
+    PLYBillingPlanType,
     PLYPlan,
     PLYPromoOffer,
     PLYSubscriptionOffer,
@@ -181,6 +182,19 @@ export interface PLYPurchasePayload {
     plan: PLYPlan;
     subscriptionOffer?: PLYSubscriptionOffer | null;
     offer?: PLYPromoOffer | null;
+    /**
+     * Billing plan the paywall resolved for this purchase. `'monthly'` means
+     * the paywall intended Apple's monthly-billing commitment (iOS 26.4+).
+     *
+     * Returning `'notHandled'` from the interceptor lets the native SDK
+     * complete the purchase and apply this billing plan itself. If you handle
+     * the purchase yourself and return `'success'`, be aware that
+     * `purchaseWithPlanVendorId` cannot carry the billing plan today, so the
+     * purchase is made up-front rather than in monthly instalments.
+     *
+     * Always `'unspecified'` on Android. See {@link PLYBillingPlanType}.
+     */
+    billingPlanType?: PLYBillingPlanType;
 }
 
 /** Typed payload for close / closeAll actions. */

--- a/packages/purchasely/src/types.ts
+++ b/packages/purchasely/src/types.ts
@@ -338,6 +338,9 @@ export type PLYEventProperties = {
  *   bridge duplicates `storeOfferId`'s value under this key.
  * - `planVendorId`, `storeProductId`, `offerVendorId`, `default` — genuinely
  *   cross-platform; both native models expose all four.
+ * - `billingPlanType` — emitted on both platforms for a stable wire shape, but
+ *   only ever meaningful on Apple (iOS 26.4+). Android's native SDK has no
+ *   commitment concept, so it is always `'unspecified'` there.
  */
 export type PLYPresentationPlan = {
   planVendorId: string | null;
@@ -350,6 +353,13 @@ export type PLYPresentationPlan = {
   storeOfferId?: string | null;
   offerVendorId?: string | null;
   default?: boolean | null;
+  /**
+   * Billing plan the paywall resolved for this plan — the backend's
+   * `commitment_billing_type`. Drives Apple's monthly-billing purchase option
+   * on iOS 26.4+. Always `'unspecified'` on Android and for plans without a
+   * commitment. See {@link PLYBillingPlanType}.
+   */
+  billingPlanType?: PLYBillingPlanType;
 };
 
 export type PLYPresentationMetadata = {


### PR DESCRIPTION
## Context

NZZ ([support thread](https://support.purchasely.io/conversations/e3b0b6c6-1479-425a-bee8-3b1c21233b76)) report that on RN 6.0.0 their annual-billed-monthly paywall (`DE_Paywall_Annual_billed_monthly`) shows the correct monthly amount, but the App Store checkout charges the **full annual price**. Their test device is on iOS 26.4.2, so the OS-version explanation is ruled out.

Apple's commitment feature is StoreKit 2 `pricingTerms` + a `.billingPlanType(.monthly)` purchase option, **iOS 26.4+ only** (per iOS 6.0.0's own headers). The native SDK resolves it from the paywall's `commitment_billing_type` into `PLYPresentationPlan.billingPlanType`, then applies it during `purchaseFromStorekit2`.

Investigating the bridge, none of that reached JS.

## What this changes

| Layer | Gap |
|---|---|
| `PLYPresentationPlan+Hybrid.m` | `asDictionary` dropped `billingPlanType` — `presentation.plans[]` couldn't distinguish a commitment plan |
| `PurchaselyRN.m` | the `purchase` interceptor payload dropped `params.billingPlanType` |
| `interceptor.ts` | `normalizePayload` whitelists keys, so JS would have dropped the field even once native sent it |
| `PurchaselyModule.kt` | Android emitted neither key |

Both bridges now emit it and the interceptor threads it through. Android has no commitment concept, so it reports `'unspecified'` for a stable wire shape — the same convention already used by `setDynamicOffering` / `getDynamicOfferings`.

Types: `billingPlanType` added to `PLYPresentationPlan` and `PLYPurchasePayload`.

## What this does NOT fix

**This is observability only — it does not fix NZZ's charge.** A purchase driven by the app still cannot carry a billing plan:

```objc
// PurchaselyRN.m:938 purchaseWithPlanVendorId
[Purchasely purchaseWithPlan:plan contentId:contentId success:… failure:…];
```

iOS 6.0.0 exposes no `purchaseWithPlan:…billingPlanType:` overload — `billingPlanType` is reachable only from the paywall JSON or `setDynamicOffering`. So an app that intercepts `purchase`, buys itself, and returns `'success'` buys **up-front**, not in instalments. Returning `'notHandled'` is unaffected: native completes the purchase and applies the billing plan itself.

That needs a native iOS SDK change. The new field at least lets an app detect the case.

## Still open

- **Whether this is NZZ's flow** — need confirmation that they intercept `purchase` rather than letting the paywall complete it. If they do, this is the root cause.
- **`{{MONTHLY_AMOUNT}}` may be wrong advice for commitment plans.** `{{AMOUNT}}` already returns the monthly instalment for NZZ, and `monthlyEquivalentPrice()` divides by 12 again → ~CHF 2.24 instead of 26.90. Which tags are commitment-aware in 6.0.0 needs verifying on an iOS 26.4+ device; not done here.
- **iOS/Android native version skew** — the podspec hard-pins `Purchasely '6.0.0'` while Android is on `io.purchasely:core:6.0.1`, so iOS can't take native patches without an RN release. Left alone deliberately; it's a release decision.

## Verification

- `yarn typecheck`, `yarn lint` — clean
- `yarn test` — 253 passed (4 new: interceptor forwards `billingPlanType`, defaults to `'unspecified'`, and two type tests)
- Both ObjC changes syntax-checked with `clang -fsyntax-only` against the real vendored 6.0.0 xcframework headers
- Kotlin not compiled locally (CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
