### PR TITLE
Version 5.7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
           ./gradlew :app:assembleDebug $GRADLE_FLAGS
 
   build-ios:
-    runs-on: macos-latest
+    # Pinned, do not move to macos-latest. This is the 5.x maintenance line:
+    # it ships React Native 0.79.2, whose bundled fmt does not compile under
+    # the Xcode 26 clang that macos-latest now carries ("call to consteval
+    # function ... is not a constant expression" in fmt/format-inl.h).
+    # macos-15 defaults to Xcode 16.4, the toolchain 5.x was released on.
+    # Drop the pin when this branch is retired, not before.
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -102,17 +108,17 @@ jobs:
             example/ios/Pods
             ~/.cocoapods
             ~/Library/Caches/CocoaPods
-          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec') }}
+          key: ${{ runner.os }}-15-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec') }}
           restore-keys: |
-            ${{ runner.os }}-cocoapods-
+            ${{ runner.os }}-15-cocoapods-
 
       - name: Cache Xcode DerivedData
         uses: actions/cache@v4
         with:
           path: example/ios/DerivedData
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'example/ios/*.xcodeproj/project.pbxproj') }}
+          key: ${{ runner.os }}-15-derived-data-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'example/ios/*.xcodeproj/project.pbxproj') }}
           restore-keys: |
-            ${{ runner.os }}-derived-data-
+            ${{ runner.os }}-15-derived-data-
 
       - name: Install CocoaPods
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  # The 5.7.3 and 6.0.0-rc.2 release events both failed and the actual publish
+  # was recovered by dispatching this workflow by hand. Keep that path open.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,15 +28,28 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # a release event already resolves to the tagged commit; this is what
+          # makes a manual workflow_dispatch on a tag check out the right code
+          ref: ${{ github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          # Node 24 ships npm 11.x. Node 22 ships npm 10.9.4, below the 11.5.1
+          # that trusted publishing needs -- which is why this used to run
+          # `npm install -g npm@latest`, the step that failed the 5.7.3 release.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Ensure npm >= 11.5.1 (required for trusted publishing)
-        run: npm install -g npm@latest
+      - name: Verify npm version (>= 11.5.1 required for trusted publishing)
+        run: |
+          NPM_VERSION="$(npm --version)"
+          echo "npm version: $NPM_VERSION"
+          if [ "$(printf '%s\n%s\n' "11.5.1" "$NPM_VERSION" | sort -V | head -n1)" != "11.5.1" ]; then
+            echo "::error::npm $NPM_VERSION is below required 11.5.1"
+            exit 1
+          fi
 
       - name: Build all packages
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,22 +53,43 @@ jobs:
           done
           echo "All package versions match release tag: $TAG"
 
+      - name: Resolve the npm dist-tag from the release tag
+        id: dist_tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          MAJOR="${TAG%%.*}"
+          PUBLISHED="$(npm view react-native-purchasely version 2>/dev/null || echo '0.0.0')"
+
+          if [ "$TAG" != "${TAG#*-}" ]; then
+            # 5.8.0-rc.1 and friends must never become `latest`
+            DIST_TAG="next"
+          elif [ "$(printf '%s\n%s\n' "$TAG" "$PUBLISHED" | sort -V | tail -n1)" = "$TAG" ]; then
+            # this release is the newest version of the package
+            DIST_TAG="latest"
+          else
+            # maintenance release on an older major: keep `latest` where it is
+            DIST_TAG="${MAJOR}.x"
+          fi
+
+          echo "release=$TAG  npm latest=$PUBLISHED  ->  dist-tag=$DIST_TAG"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Publish react-native-purchasely
         working-directory: packages/purchasely
-        run: npm publish --access public --provenance --tag 5.x
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-google
         working-directory: packages/google
-        run: npm publish --access public --provenance --tag 5.x
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-amazon
         working-directory: packages/amazon
-        run: npm publish --access public --provenance --tag 5.x
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-huawei
         working-directory: packages/huawei
-        run: npm publish --access public --provenance --tag 5.x
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-android-player
         working-directory: packages/android-player
-        run: npm publish --access public --provenance --tag 5.x
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,20 +55,20 @@ jobs:
 
       - name: Publish react-native-purchasely
         working-directory: packages/purchasely
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag 5.x
 
       - name: Publish @purchasely/react-native-purchasely-google
         working-directory: packages/google
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag 5.x
 
       - name: Publish @purchasely/react-native-purchasely-amazon
         working-directory: packages/amazon
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag 5.x
 
       - name: Publish @purchasely/react-native-purchasely-huawei
         working-directory: packages/huawei
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag 5.x
 
       - name: Publish @purchasely/react-native-purchasely-android-player
         working-directory: packages/android-player
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag 5.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,13 @@ jobs:
             # this release is the newest version of the package
             DIST_TAG="latest"
           else
-            # maintenance release on an older major: keep `latest` where it is
-            DIST_TAG="${MAJOR}.x"
+            # Maintenance release on an older major: keep `latest` where it is.
+            # The `release-` prefix is required, not cosmetic: npm refuses any
+            # dist-tag that parses as a SemVer range, so `5.x`, `v5` and `5`
+            # all fail with "Tag name must not be a valid SemVer range".
+            # Consumers are unaffected -- `npm i <pkg>@5.x` still resolves as a
+            # version range, which needs no dist-tag at all.
+            DIST_TAG="release-${MAJOR}"
           fi
 
           echo "release=$TAG  npm latest=$PUBLISHED  ->  dist-tag=$DIST_TAG"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@
 
 | Property | Value |
 |----------|-------|
-| Current Version | 5.7.3 |
+| Current Version | 5.7.4 |
 | React Native | 0.79.2 |
 | TypeScript | 5.2.2 (strict mode) |
 | Node.js | v20 (see `.nvmrc`) |
 | Package Manager | Yarn 3.6.1 (workspaces) |
-| Native iOS SDK | 5.7.4 |
-| Native Android SDK | 5.7.4 |
+| Native iOS SDK | 5.7.9 |
+| Native Android SDK | 5.7.5 |
 
 ### Supported App Stores
 - Apple App Store (iOS)
@@ -388,11 +388,11 @@ Build orchestration with caching:
 ### Native Dependencies
 
 **iOS (CocoaPods):**
-- Purchasely SDK v5.7.4
+- Purchasely SDK v5.7.9
 - Deployment target: iOS 13.4
 
 **Android (Gradle):**
-- io.purchasely:core:5.7.4
+- io.purchasely:core:5.7.5
 - Min SDK: 21
 - Kotlin: 1.9+
 - Java: 11
@@ -630,6 +630,7 @@ See `VERSIONS.md` for native SDK version mapping:
 
 | React Native SDK | iOS SDK | Android SDK |
 |------------------|---------|-------------|
+| 5.7.4 | 5.7.9 | 5.7.5 |
 | 5.7.3 | 5.7.4 | 5.7.4 |
 | 5.7.2 | 5.7.2 | 5.7.3 |
 | 5.7.1 | 5.7.1 | 5.7.1 |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -114,3 +114,4 @@ This file provides the underlying native SDK versions that the React Native SDK 
 | 5.7.1   | 5.7.1       | 5.7.1           |
 | 5.7.2   | 5.7.2       | 5.7.3           |
 | 5.7.3   | 5.7.4       | 5.7.4           |
+| 5.7.4   | 5.7.9       | 5.7.5           |

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,5 +31,20 @@ target 'example' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # TODO(fmt-consteval): remove once React Native ships a fmt version that
+    # compiles under Xcode 26.x clang. Tracking: upstream fmt + RN bundled fmt.
+    # Xcode 26 / recent Clang reject fmt's consteval-based compile-time
+    # format-string checks ("call to consteval function ... is not a constant
+    # expression"). Disable fmt's consteval path on every target so the bundled
+    # fmt pod and its consumers (Folly, React-*) build under Xcode 26.x.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        defs = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        defs = [defs] unless defs.is_a?(Array)
+        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
+      end
+    end
   end
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,20 +31,5 @@ target 'example' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
-
-    # TODO(fmt-consteval): remove once React Native ships a fmt version that
-    # compiles under Xcode 26.x clang. Tracking: upstream fmt + RN bundled fmt.
-    # Xcode 26 / recent Clang reject fmt's consteval-based compile-time
-    # format-string checks ("call to consteval function ... is not a constant
-    # expression"). Disable fmt's consteval path on every target so the bundled
-    # fmt pod and its consumers (Folly, React-*) build under Xcode 26.x.
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        defs = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
-        defs = [defs] unless defs.is_a?(Array)
-        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
-      end
-    end
   end
 end

--- a/packages/amazon/android/build.gradle
+++ b/packages/amazon/android/build.gradle
@@ -61,5 +61,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:amazon:5.7.4'
+  implementation 'io.purchasely:amazon:5.7.5'
 }

--- a/packages/amazon/package.json
+++ b/packages/amazon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-amazon",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Amazon In-App Purchases dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/android-player/android/build.gradle
+++ b/packages/android-player/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:player:5.7.4'
+  implementation 'io.purchasely:player:5.7.5'
 }

--- a/packages/android-player/package.json
+++ b/packages/android-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-android-player",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Player Android",
   "source": "./src/index.ts",
   "main": "./lib/commonjs/index.js",

--- a/packages/google/android/build.gradle
+++ b/packages/google/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:google-play:5.7.4'
+  implementation 'io.purchasely:google-play:5.7.5'
 }

--- a/packages/google/package.json
+++ b/packages/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-google",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Google Play Billing dependency",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/huawei/android/build.gradle
+++ b/packages/huawei/android/build.gradle
@@ -65,5 +65,5 @@ dependencies {
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation 'io.purchasely:huawei-services:5.7.4'
+  implementation 'io.purchasely:huawei-services:5.7.5'
 }

--- a/packages/huawei/package.json
+++ b/packages/huawei/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@purchasely/react-native-purchasely-huawei",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely Huawei Mobile Services dependencies",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/android/build.gradle
+++ b/packages/purchasely/android/build.gradle
@@ -138,7 +138,7 @@ dependencies {
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 
-  api 'io.purchasely:core:5.7.4'
+  api 'io.purchasely:core:5.7.5'
   api 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
 
   // Test dependencies

--- a/packages/purchasely/package.json
+++ b/packages/purchasely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-purchasely",
   "title": "Purchasely React Native",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Purchasely is a solution to ease the integration and boost your In-App Purchase & Subscriptions on the App Store, Google Play Store and Huawei App Gallery.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/packages/purchasely/react-native-purchasely.podspec
+++ b/packages/purchasely/react-native-purchasely.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React-Core"
-  s.dependency "Purchasely", '5.7.4'
+  s.dependency "Purchasely", '5.7.9'
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'ios/PurchaselyTests/**/*.{h,m,mm,swift}'

--- a/packages/purchasely/src/__tests__/index.test.ts
+++ b/packages/purchasely/src/__tests__/index.test.ts
@@ -182,7 +182,7 @@ describe('Purchasely SDK', () => {
                 'test-user',
                 mockConstants.logLevelDebug,
                 mockConstants.runningModeFull,
-                '5.7.3'
+                '5.7.4'
             )
         })
 
@@ -203,7 +203,7 @@ describe('Purchasely SDK', () => {
                 null,
                 mockConstants.logLevelError,
                 mockConstants.runningModeFull,
-                '5.7.3'
+                '5.7.4'
             )
         })
 

--- a/packages/purchasely/src/__tests__/types.test.ts
+++ b/packages/purchasely/src/__tests__/types.test.ts
@@ -328,7 +328,7 @@ describe('Purchasely Types', () => {
             const event: PurchaselyEvent = {
                 name: 'PURCHASE_TAPPED',
                 properties: {
-                    sdk_version: '5.7.3',
+                    sdk_version: '5.7.4',
                     event_name: 'PURCHASE_TAPPED',
                     event_created_at_ms: 1705315200000,
                     event_created_at: '2024-01-15T12:00:00Z',
@@ -339,7 +339,7 @@ describe('Purchasely Types', () => {
             }
 
             expect(event.name).toBe('PURCHASE_TAPPED')
-            expect(event.properties.sdk_version).toBe('5.7.3')
+            expect(event.properties.sdk_version).toBe('5.7.4')
         })
     })
 

--- a/packages/purchasely/src/index.ts
+++ b/packages/purchasely/src/index.ts
@@ -28,7 +28,7 @@ import type {
   PurchaselyUserAttribute,
 } from './types';
 
-const purchaselyVersion = '5.7.3';
+const purchaselyVersion = '5.7.4';
 
 const constants = NativeModules.Purchasely.getConstants() as Constants;
 


### PR DESCRIPTION
## React Native SDK 5.7.4

Maintenance release on the **5.x line**. Requested by **Fantaleague (MPG)** — support conversation [25179430](https://support.purchasely.io/conversations/25179430-57b0-4d26-84a8-c09cc5c16977). They run the RN bridge 5.7.3 with native 5.7.4 in production (`Purchasely/5.7.4 ReactNative/5.7.3 Mode/full`) and cannot pick up the iOS SDK without an npm release.

### Native SDK updates

| | Before | After | Published |
|---|---|---|---|
| iOS | 5.7.4 | **5.7.9** | ✅ CocoaPods (pushed 2026-09-01 13:57 UTC) |
| Android | 5.7.4 | **5.7.5** | ✅ Maven Central, all 5 artifacts |

### Base branch

`main` is already at **6.0.0**, so this cannot target it without regressing the version. This PR targets `release/5.x`, a new maintenance branch cut from the 5.7.3 release commit (`f84a05a`). No post-5.7.3 commit from `main` is included — the diff is version pins plus the CI/publish fixes below.

### Version bump

- `packages/purchasely/react-native-purchasely.podspec` — iOS pin 5.7.9
- `packages/{purchasely,google,amazon,huawei,android-player}/android/build.gradle` — Android pins 5.7.5
- `packages/*/package.json` + `packages/purchasely/src/index.ts` — version 5.7.4 (via `./prepare.sh 5.7.4`)
- `packages/purchasely/src/__tests__/{index,types}.test.ts` — version expectations
- `VERSIONS.md`, `CLAUDE.md` — version history and docs

### Three CI/release fixes that the bump exposed

**1. `ci.yml` did not run on this PR at all.** It triggered only on `pull_request` against `main`, so a PR to the maintenance branch got zero checks and was mergeable with nothing verified. Added `release/**` to the trigger list.

**2. `build-ios` pinned to `macos-15`.** `macos-latest` has rolled forward to `macos-26-arm64` (Xcode 26.6), whose clang rejects the consteval format-string checks in the fmt bundled with React Native 0.79.2. `macos-15` defaults to Xcode 16.4, the toolchain 5.x was released on. `macos-26` ships no Xcode 16, so selecting a toolchain on the newer image was not an option. Both cache keys are now scoped to the image — they keyed on `runner.os` alone (`"macOS"`), so `restore-keys` would drop an Xcode 26 `DerivedData` and SDK 26 Pods into an Xcode 16 build.

A first attempt at `FMT_USE_CONSTEVAL=0` in the Podfile is reverted in this branch. The define did reach the pod targets and fmt failed anyway; that block was copied from `main`, where RN 0.86 bundles a fmt that compiles under Xcode 26 regardless, so it had never actually been exercised.

**3. npm dist-tag derived from the release tag.** `react-native-purchasely@latest` resolves to 6.0.0, and `npm publish` without `--tag` applies `latest` regardless of semver order — so this release would have handed every new install the old major. `publish.yml` now resolves the dist-tag from `github.ref_name`:

| Release tag | dist-tag |
|---|---|
| `5.7.4` | `release-5` |
| `6.0.1`, `6.1.0`, `7.0.0` | `latest` |
| `6.1.0-rc.1` | `next` |

Derived, not hardcoded, so no major needs a workflow edit. `release-` is a required prefix, not cosmetic: npm refuses any dist-tag that parses as a SemVer range, so `5.x`, `v5` and `5` are all rejected with `Tag name must not be a valid SemVer range`. Consumers are unaffected — `npm i react-native-purchasely@5.x` resolves as a version range and never consults a dist-tag.

Behaviour change worth a maintainer's eye: prereleases now go to `next`. Until now an rc published without `--tag` took `latest` for itself.

### ⚠️ Open dependency: a companion PR on `main`

`main`'s `publish.yml` hardcodes `--tag latest` on all five packages, and it also carries `workflow_dispatch` plus `with: ref: ${{ github.ref }}` on the checkout — neither of which exists at the 5.7.3 commit this branch is cut from. The repo's real publishes have gone out as a `workflow_dispatch` on `main` (the `5.7.3` release event failed and was recovered that way an hour later; same shape for `6.0.0-rc.2`), and a dispatch unambiguously runs `main`'s workflow.

So the dist-tag logic must also land on `main`, otherwise creating the `5.7.4` release can still set `latest` to 5.7.4. **Do not create the release until that PR is merged.** Raised by Greptile on this PR; the thread is left open on purpose.

### Verification

| Check | Result |
|---|---|
| `yarn test` | ✅ 139 passed / 139, 4 suites |
| `yarn lint` | ✅ 0 |
| `yarn typecheck` | ✅ 0 |
| `yarn install` | ✅ `yarn.lock` unchanged |
| `npm publish --dry-run --tag release-5` | ✅ accepted (`--tag 5.x` errors) |
| CI | see checks |

### Release sequence

1. Merge the companion `publish.yml` PR on `main`
2. Merge this PR into `release/5.x`
3. `gh release create 5.7.4 --target release/5.x` — bare tag, no `v` prefix
4. Confirm `npm view react-native-purchasely dist-tags` still shows `latest: 6.x` and a new `release-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)