### PR TITLE
fix(ci): derive the npm dist-tag from the release tag, run CI on release/**

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+      # maintenance branches for older majors (release/5.x, ...). Without this
+      # a PR targeting one gets zero checks and stays mergeable unverified.
+      - 'release/**'
   merge_group:
     types:
       - checks_requested

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,15 @@ jobs:
         run: |
           TAG="${{ github.ref_name }}"
           MAJOR="${TAG%%.*}"
-          PUBLISHED="$(npm view react-native-purchasely version 2>/dev/null || echo '0.0.0')"
+
+          # Fail closed. A default here would be a default towards `latest`:
+          # any real version sorts above a placeholder, so a registry blip
+          # during a 5.x release would hand `latest` to the older major. There
+          # is no safe guess, so refuse to publish instead.
+          if ! PUBLISHED="$(npm view react-native-purchasely version 2>/dev/null)" || [ -z "$PUBLISHED" ]; then
+            echo "::error::could not read the published version of react-native-purchasely from npm; refusing to guess the dist-tag"
+            exit 1
+          fi
 
           if [ "$TAG" != "${TAG#*-}" ]; then
             # 6.1.0-rc.1 and friends must never become `latest`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,22 +62,48 @@ jobs:
           done
           echo "All package versions match release tag: $TAG"
 
+      - name: Resolve the npm dist-tag from the release tag
+        id: dist_tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          MAJOR="${TAG%%.*}"
+          PUBLISHED="$(npm view react-native-purchasely version 2>/dev/null || echo '0.0.0')"
+
+          if [ "$TAG" != "${TAG#*-}" ]; then
+            # 6.1.0-rc.1 and friends must never become `latest`
+            DIST_TAG="next"
+          elif [ "$(printf '%s\n%s\n' "$TAG" "$PUBLISHED" | sort -V | tail -n1)" = "$TAG" ]; then
+            # this release is the newest version of the package
+            DIST_TAG="latest"
+          else
+            # Maintenance release on an older major: keep `latest` where it is.
+            # The `release-` prefix is required, not cosmetic: npm refuses any
+            # dist-tag that parses as a SemVer range, so `5.x`, `v5` and `5`
+            # all fail with "Tag name must not be a valid SemVer range".
+            # Consumers are unaffected -- `npm i <pkg>@5.x` still resolves as a
+            # version range, which needs no dist-tag at all.
+            DIST_TAG="release-${MAJOR}"
+          fi
+
+          echo "release=$TAG  npm latest=$PUBLISHED  ->  dist-tag=$DIST_TAG"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Publish react-native-purchasely
         working-directory: packages/purchasely
-        run: npm publish --access public --provenance --tag latest
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-google
         working-directory: packages/google
-        run: npm publish --access public --provenance --tag latest
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-amazon
         working-directory: packages/amazon
-        run: npm publish --access public --provenance --tag latest
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-huawei
         working-directory: packages/huawei
-        run: npm publish --access public --provenance --tag latest
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"
 
       - name: Publish @purchasely/react-native-purchasely-android-player
         working-directory: packages/android-player
-        run: npm publish --access public --provenance --tag latest
+        run: npm publish --access public --provenance --tag "${{ steps.dist_tag.outputs.dist_tag }}"


### PR DESCRIPTION
Ports the two CI fixes from the 5.7.4 maintenance release (#285) that belong on `main`.

## 1. `publish.yml` hardcoded `--tag latest`

`npm publish` applies the `latest` dist-tag regardless of SemVer ordering. Publishing any maintenance release of an older major would therefore hand every new `npm install react-native-purchasely` the old code — silently, with no error.

The dist-tag is now resolved from `github.ref_name`:

| Release tag | npm `latest` at the time | dist-tag |
|---|---|---|
| `5.7.4` | 6.0.0 | `release-5` |
| `6.0.1`, `6.1.0`, `7.0.0` | 6.0.0 | `latest` |
| `6.1.0-rc.1` | 6.0.0 | `next` |
| `4.5.3` | 6.0.0 | `release-4` |

Derived rather than hardcoded, so no future major needs a workflow edit.

### The `release-` prefix is load-bearing

npm refuses any dist-tag that parses as a SemVer range, so the obvious `5.x` does not work:

```console
$ node -e "console.log(require('semver').validRange('5.x'))"
>=5.0.0 <6.0.0-0

$ npm publish --dry-run --tag 5.x
npm error Tag name must not be a valid SemVer range: 5.x

$ npm publish --dry-run --tag release-5
npm notice Publishing to https://registry.npmjs.org/ with tag release-5 (dry-run)
```

`5.x`, `v5` and `5` are all rejected. Consumers lose nothing — `npm i react-native-purchasely@5.x` resolves as a version *range* and never consults a dist-tag.

### ⚠️ Behaviour change worth a second opinion

Prereleases now land on `next`. Until now an rc published without `--tag` claimed `latest` for itself, which is how `6.0.0-rc.x` briefly became the default install. Say so if you would rather keep the old behaviour.

## 2. `ci.yml` did not run on maintenance-branch PRs

The trigger was `pull_request: branches: [main]` only. PR #285 targeted `release/5.x` and got **zero checks** — no lint, no test, no native builds — while still showing as mergeable. Added `release/**`.

## Deliberately not ported

The `macos-15` pin on `build-ios`. That one works around React Native 0.79.2's bundled fmt failing under Xcode 26 clang (`call to consteval function ... is not a constant expression`). `main` is on React Native 0.86, whose fmt builds fine on `macos-latest` — pinning here would be a regression.

Also left alone: scoping the iOS cache keys to the runner image. On the 5.x branch that was a companion to the pin, since `restore-keys` could drop an Xcode 26 `DerivedData` into an Xcode 16 build. `main` has a single image so the hazard only returns at the next `macos-latest` roll. Worth doing eventually, out of scope here.

## Context

Verified during the 5.7.4 release that the `release` event runs `publish.yml` **from the tagged commit**, not from the default branch: the run for tag `5.7.4` (targeting `release/5.x`) executed that branch's 4-job CI, not `main`'s 7-job CI. So this change is not what unblocked 5.7.4 — it prevents the next maintenance release from silently rolling `latest` back if it is ever cut from a branch that lacks the fix, and it makes the outcome independent of which workflow file GitHub picks.

## Test plan

- [x] `ruby -e "YAML.safe_load"` on both workflow files
- [x] Dist-tag resolution exercised against all 8 real tag/latest combinations
- [x] `npm publish --dry-run` confirms `release-5` is accepted and `5.x` is not
- [ ] CI green on this PR
- [ ] Next release publishes under the expected dist-tag (check `npm view react-native-purchasely dist-tags`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)