### PR TITLE
ci(e2e-ios): build idb-companion with the newest Xcode on the runner

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -83,7 +83,37 @@ jobs:
           # idb_companion : tap Facebook (nécessite brew trust sur les brew récents).
           brew tap facebook/fb
           brew trust facebook/fb || true
-          brew install idb-companion
+
+          # idb-companion se compile depuis les sources et exige un Xcode COMPLET
+          # au moins aussi récent que celui que la formule déclare (26.0 à ce
+          # jour). Le job sélectionne volontairement Xcode 16.x pour builder l'app
+          # (RN 0.86), et brew refusait donc l'installation :
+          #   "A full installation of Xcode.app 26.0 is required to compile this
+          #    software" → l'étape échouait avant même de builder quoi que ce soit,
+          # ce qui laissait ce workflow rouge toutes les nuits.
+          #
+          # On sélectionne donc le Xcode le plus récent disponible le temps du
+          # `brew install`, puis on restaure celui du job. Les deux besoins sont
+          # indépendants : compiler idb-companion, et compiler l'app.
+          ORIGINAL_XCODE=$(xcode-select -p)
+          NEWEST_XCODE=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$NEWEST_XCODE" ] && [ "$NEWEST_XCODE/Contents/Developer" != "$ORIGINAL_XCODE" ]; then
+            echo "Selecting $NEWEST_XCODE to build idb-companion"
+            sudo xcode-select -s "$NEWEST_XCODE/Contents/Developer"
+          fi
+
+          # `|| true` : on restaure la sélection Xcode AVANT de décider de l'échec,
+          # sinon un `set -e` laisserait le runner sur le mauvais Xcode pour le
+          # build de l'app.
+          brew install idb-companion || IDB_COMPANION_FAILED=1
+
+          sudo xcode-select -s "$ORIGINAL_XCODE"
+          echo "Restored Xcode: $(xcodebuild -version | head -1)"
+
+          if [ -n "${IDB_COMPANION_FAILED:-}" ]; then
+            echo "::error::brew install idb-companion failed. Newest Xcode on this runner: ${NEWEST_XCODE:-none}. The formula needs a full Xcode at least as recent as the one it declares — this image may need bumping."
+            exit 1
+          fi
           # fb-idb (client Python) ne supporte pas Python 3.14 (asyncio.get_event_loop
           # y lève) — on l'isole dans un venv 3.11/3.12/3.13 déterministe et on
           # exporte le binaire via $IDB (lu par les drivers tap/swipe).


### PR DESCRIPTION
`e2e-ios.yml` has been red every night on `main` since at least **2026-08-27**, and it never reached a test — it died in the setup step, before building anything.

## Why

`idb-companion` compiles from source and requires a full Xcode at least as recent as the one its formula declares (26.0 today). The job deliberately selects Xcode 16.x to build the app, since RN 0.86 needs >= 16.1. So brew refused:

```
idb-companion: A full installation of Xcode.app 26.0 is required to compile
this software. Installing just the Command Line Tools is not sufficient.
```

Every nightly run since then: `E2E Tests (iOS T1-T27)  fail  ~1m40s`.

## Fix

The two needs are independent — compiling `idb-companion`, and compiling the app. The newest Xcode on the runner is selected for the `brew install` only, then the job's own selection is restored.

Two details worth the extra lines:

- The restore happens **before** the failure is acted on. Otherwise a brew failure would leave the runner pointing at the wrong Xcode for the app build, turning one clear error into a confusing second one.
- On failure the message names the newest Xcode it found, so a runner image that ships none reads as an image problem rather than a mystery.

## Verification

I cannot exercise this without pushing it — the failure only reproduces on the runner image. Locally the same class of problem hits the Python client (`fb-idb` does not support Python 3.14, `asyncio.get_event_loop` raises), which this workflow already works around with a version-pinned venv; rebuilding `idb` in a 3.12 venv is what let T8/T9/T25 pass on my machine.

So: merging this is the test. If the job still fails, the error line will say which Xcodes the image actually has.

Split out of #289 deliberately — CI infrastructure does not belong inside a bug-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)