### PR TITLE
ci(ios): build the bridge under use_frameworks!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,69 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             build
 
+  # Regression guard for the client-reported build failure fixed by b99a2d1:
+  # under `use_frameworks!`, the pod's generated Swift header lands in
+  # `react_native_purchasely.framework/Headers/` instead of `DerivedSources/`,
+  # so the quoted `#import "react_native_purchasely-Swift.h"` in PurchaselyRN.m
+  # was not found. Every other iOS job installs pods WITHOUT `use_frameworks!`,
+  # so none of them compiles that layout.
+  #
+  # Only the `react-native-purchasely` pod scheme is built: the discriminating
+  # unit is whether PurchaselyRN.m compiles inside a framework-layout target.
+  # Building the whole example app under `use_frameworks!` would add unrelated
+  # pod failure surface to a header-resolution check.
+  #
+  # `static` linkage only. The reporter saw `:linkage => :static` and `:dynamic`
+  # fail on the very same header path, and both put the header in the framework
+  # bundle, so the second linkage costs a macOS runner and proves nothing new.
+  build-ios-frameworks:
+    name: iOS Build (use_frameworks!)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build library
+        run: yarn prepare
+
+      # Download caches only (content-addressed, shared with the other iOS
+      # jobs). The generated `Pods` tree is never cached -- see build-ios.
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cocoapods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-cocoapods-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cocoapods-
+
+      # No DerivedData cache: its key in the other iOS jobs hashes the same
+      # files, so both layouts would share one entry and hand each other object
+      # files built for the wrong linkage.
+      - name: Install CocoaPods with use_frameworks!
+        run: |
+          cd example/ios
+          pod install --repo-update
+        env:
+          NO_FLIPPER: 1
+          # Read by example/ios/Podfile -> use_frameworks! :linkage => :static
+          USE_FRAMEWORKS: static
+
+      - name: Build the react-native-purchasely pod under use_frameworks!
+        run: |
+          xcodebuild \
+            -workspace example/ios/example.xcworkspace \
+            -scheme react-native-purchasely \
+            -configuration Debug \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath example/ios/DerivedDataFrameworks \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
   ios-unit-tests:
     name: iOS Unit Tests (bridge)
     runs-on: macos-latest


### PR DESCRIPTION
## Why

Customer report of a v6 build failure while migrating from 5.6.2 to 6.0.0 on React Native 0.86 / Expo 57:

```
node_modules/react-native-purchasely/ios/PurchaselyRN.m:25:9:
error: 'react_native_purchasely-Swift.h' file not found
```

His app must use `use_frameworks!` (imposed by Firebase and others). Under `use_frameworks!` the pod's generated Swift header lands in `react_native_purchasely.framework/Headers/`, not in `DerivedSources/`, so the quoted import added in v6 for `PLYTransitionFactory` does not resolve.

Commit b99a2d1 already fixed the import with an `__has_include` guard, but **no CI job installs pods with `use_frameworks!`**, so nothing protects the fix. This PR adds that job.

## Verification (local, this branch, static linkage)

| State | Result |
|---|---|
| b99a2d1 reverted, `USE_FRAMEWORKS=static` | `PurchaselyRN.m:25:9: error: 'react_native_purchasely-Swift.h' file not found` — the reporter's exact error |
| b99a2d1 restored, same DerivedData | `** BUILD SUCCEEDED **`, header resolved from `react_native_purchasely.framework/Headers/` |
| No `use_frameworks!` (control) | `** BUILD SUCCEEDED **`, header resolved from `DerivedSources/` |

The guard therefore covers both layouts, and the new job fails if anyone reintroduces the quoted-only import.

## Notes

- No Podfile change: `example/ios/Podfile` already reads the `USE_FRAMEWORKS` env var.
- A **new job**, not a matrix on `build-ios`: a matrix renames that check and would drop it from the branch protection gate.
- Only the `react-native-purchasely` pod scheme is built. The discriminating unit is whether `PurchaselyRN.m` compiles in a framework-layout target; building the whole example app under `use_frameworks!` would add unrelated pod failure surface.
- No DerivedData cache: the existing key hashes the same files, so the two layouts would share one entry and swap object files.
- `static` linkage only: the reporter saw `:static` and `:dynamic` fail on the same header path, and both use the framework bundle layout.

Related: the second issue in the same report (Android, only the first `handleDeeplink()` of a session works) is tracked in MOB-458 and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)