### PR TITLE
ci: share the caches across PRs, delete the ones that do nothing

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,53 @@
+name: Cleanup PR caches
+
+# Actions cache is capped at 10 GB per repository, and GitHub evicts the
+# least-recently-used entries once the cap is reached. The Gradle caches alone
+# are ~1.5 GB per PR ref, so a handful of stale refs is enough to evict the
+# entries the open PRs actually restore. GitHub only expires a cache after 7
+# days without a read; this deletes a PR's caches the moment it closes, which
+# is as soon as they are certainly dead.
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    # A pull_request run from a fork gets a read-only GITHUB_TOKEN, so the
+    # deletion would fail. Skip instead of failing loudly.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      # The only write scope this workflow needs.
+      actions: write
+    steps:
+      - name: Delete every cache scoped to the closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # The ref an `actions/cache` entry is written under during a
+          # pull_request run.
+          CACHE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+
+          ids=$(gh api --paginate \
+            "repos/$GH_REPO/actions/caches?ref=$CACHE_REF&per_page=100" \
+            --jq '.actions_caches[].id')
+
+          if [ -z "$ids" ]; then
+            echo "No cache entry for $CACHE_REF."
+            exit 0
+          fi
+
+          count=0
+          for id in $ids; do
+            # Keep going on a single failure: another run of this workflow, or
+            # GitHub's own eviction, may have removed the entry already.
+            if gh api -X DELETE "repos/$GH_REPO/actions/caches/$id" >/dev/null; then
+              count=$((count + 1))
+            else
+              echo "Could not delete cache $id, continuing."
+            fi
+          done
+          echo "Deleted $count cache entries for $CACHE_REF."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: CI
 on:
   workflow_call:
   workflow_dispatch:
+  # A cache written during a `pull_request` run is scoped to that PR's ref and
+  # is unreadable from any other branch; only the default branch's scope is
+  # shared. Without this trigger no run ever writes there, so every PR
+  # reinstalled its pods and node_modules from cold. One run per merge seeds
+  # the caches that every later PR restores.
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -131,15 +139,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cocoapods-
 
-      # Exact-match only (no restore-keys): a partial hit would mix object
-      # files built against a different Pods install, the same staleness class
-      # of failure described above.
-      - name: Cache Xcode DerivedData
-        uses: actions/cache@v4
-        with:
-          path: example/ios/DerivedData
-          key: ${{ runner.os }}-derived-data-${{ hashFiles('example/ios/Podfile', 'packages/purchasely/react-native-purchasely.podspec', 'example/ios/*.xcodeproj/project.pbxproj', 'yarn.lock') }}
-
+      # No DerivedData cache. It used to be cached here, exact-key, but it never
+      # hit: until the `push: main` trigger above, no run wrote to the shared
+      # cache scope. Measured once it did hit (runs 33867614845 cold ->
+      # 33868869757 warm, same commit): `Prebuild CocoaPods targets` 231 s ->
+      # 202 s and the XCTest job 180 s -> 178 s, i.e. run-to-run variance and
+      # no reuse. `pod install` regenerates the Pods project on every run, so
+      # Xcode discards the restored objects and rebuilds regardless. 222 MB of
+      # a repository cache quota that is already at its cap, for nothing.
       - name: Install CocoaPods
         run: |
           cd example/ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ on:
     types:
       - checks_requested
 
+# A force-push to a PR used to leave the previous run alive: 8 jobs, two of
+# them on macOS runners. e2e-android.yml and e2e-ios.yml already do this.
+concurrency:
+  group: ci-${{ github.ref }}
+  # Cancel superseded PR runs only. A `push: main` run must finish -- it is the
+  # one that seeds the shared cache scope -- and a merge_group or release run
+  # must never be cancelled either.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -330,7 +339,23 @@ jobs:
       - name: Build local v6 packages
         run: yarn all:prepare
 
+      # `npm ci` in this project took 416 s, uncached: it is outside the yarn
+      # workspace, so the `Setup` action's node_modules cache does not cover
+      # it. Caching it is safe because the three local packages are RELATIVE
+      # SYMLINKS into ../../packages (verified: node_modules/react-native-purchasely
+      # -> ../../../packages/purchasely), so a restored tree still points at
+      # this checkout's freshly built packages, never at a stale copy. Only
+      # third-party dependencies are cached, and they move only with the
+      # lockfile that keys this entry.
+      - name: Restore RN 0.86 test project dependencies
+        id: rn086-node-modules
+        uses: actions/cache@v4
+        with:
+          path: test-projects/rn-purchasely-test/node_modules
+          key: ${{ runner.os }}-rn086-node-modules-${{ hashFiles('test-projects/rn-purchasely-test/package-lock.json') }}
+
       - name: Install RN 0.86 test project dependencies
+        if: steps.rn086-node-modules.outputs.cache-hit != 'true'
         working-directory: test-projects/rn-purchasely-test
         run: npm ci --ignore-scripts
 
@@ -379,7 +404,23 @@ jobs:
       - name: Build local v6 packages
         run: yarn all:prepare
 
+      # `npm ci` in this project took 416 s, uncached: it is outside the yarn
+      # workspace, so the `Setup` action's node_modules cache does not cover
+      # it. Caching it is safe because the three local packages are RELATIVE
+      # SYMLINKS into ../../packages (verified: node_modules/react-native-purchasely
+      # -> ../../../packages/purchasely), so a restored tree still points at
+      # this checkout's freshly built packages, never at a stale copy. Only
+      # third-party dependencies are cached, and they move only with the
+      # lockfile that keys this entry.
+      - name: Restore RN 0.86 test project dependencies
+        id: rn086-node-modules
+        uses: actions/cache@v4
+        with:
+          path: test-projects/rn-purchasely-test/node_modules
+          key: ${{ runner.os }}-rn086-node-modules-${{ hashFiles('test-projects/rn-purchasely-test/package-lock.json') }}
+
       - name: Install RN 0.86 test project dependencies
+        if: steps.rn086-node-modules.outputs.cache-hit != 'true'
         working-directory: test-projects/rn-purchasely-test
         run: npm ci --ignore-scripts
 


### PR DESCRIPTION
Three cache changes to `ci.yml`, plus a new `cache-cleanup.yml`. Every claim below is measured, and two of my own earlier proposals were dropped because the measurement said no.

## 1. `push: branches: [main]` — the linchpin

A cache written during a `pull_request` run is scoped to that PR's ref, and no other branch can read it. Only the default branch's scope is shared. `ci.yml` had no `push` trigger, so **no run ever wrote to the shared scope** and every PR started cold.

Confirmed against the API: the only `macOS-derived-data` entry, and the only `macOS-cocoapods` entry with ci.yml's key, sat on `refs/pull/294/merge`. Nothing on `refs/heads/main`. The 405 MB `macOS-cocoapods` on main belongs to the nightly E2E workflow, different key.

Cold against warm on the same commit, runs 33867614845 then 33868869757:

| Step | Cold | Warm |
|---|---|---|
| `pod install`, build-ios | 74 s | **41 s** |
| `pod install`, XCTest job | 71 s | **28 s** |

Cost: one CI run per merge.

## 2. The DerivedData cache is deleted

This reverses my first proposal in this PR, which added a *second* DerivedData cache for the XCTest job. The warm run above shows why that was wrong: the existing DerivedData cache **was restored** — 10 s, and no re-save, so a primary-key hit — and changed nothing.

| Step | Cold | Warm |
|---|---|---|
| Prebuild CocoaPods targets | 231 s | 202 s |
| XCTest suite | 180 s | 178 s |

Run-to-run variance, no reuse. `pod install` regenerates the Pods project on every run, so Xcode discards the restored objects and rebuilds regardless. So the step is removed instead of duplicated: 222 MB of a quota already at its cap, for nothing. The comment left in its place records the measurement so nobody adds it back.

## 3. Cache the RN 0.86 test project's `node_modules`

`Install RN 0.86 test project dependencies` is the least predictable step in the pipeline. Ten observations of the same `npm ci --ignore-scripts`, same lockfile, no cache in any of them:

| Run | android | ios |
|---|---|---|
| 33864735329 | 416 s | 26 s |
| 33867614845 | 424 s | 55 s |
| 33868869757 | 167 s | 15 s |
| 33869707232 | 422 s | 422 s |
| 33881098868 | 18 s | 15 s |

The step is not systematically slow — 18 s is its floor — but it exceeded 165 s in four of the five Ubuntu runs, and once on macOS too. The cost is environmental, not the command's. Nothing cached it, because `test-projects/rn-purchasely-test` sits outside the yarn workspace and the `Setup` action's node_modules cache does not reach it.

Warm measurement, run 33883133085:

| Job | Restore | `npm ci` |
|---|---|---|
| build-rn-0-86-android | 2 s | skipped |
| build-rn-0-86-ios | 11 s | skipped |

So the step goes from a 15–424 s exposure to a 2–11 s restore.

Caching it is safe because the three local packages are **relative symlinks** into `../../packages` (verified: `node_modules/react-native-purchasely -> ../../../packages/purchasely`), so a restored tree still resolves to this checkout's packages, which `Build local v6 packages` rebuilds in the same job. Only third-party dependencies come from the cache, and they move only with the lockfile that keys the entry.

## 4. `concurrency` group

`e2e-android.yml:35` and `e2e-ios.yml:33` both have one; `ci.yml` did not, so a force-push left the previous run's 8 jobs alive, two of them on macOS. Cancellation is limited to `pull_request`: a `push: main` run seeds the shared cache scope and must finish, and a `merge_group` or release run must never be cancelled.

## 5. `cache-cleanup.yml`

The 10 GB repository cap was already exceeded, at 10.81 GB, so GitHub was evicting live entries to keep dead ones: `refs/pull/289/merge` still held about 1.4 GB of Gradle caches after that PR merged. GitHub expires an unread cache only after 7 days; a closed PR is the earliest certain signal. The workflow needs `actions: write` and nothing else, and it skips fork PRs, whose token cannot delete.

It cannot be exercised before it merges: `pull_request: closed` only fires for a PR that already carries the file. The first PR to close after this lands is its live test.

## Not in this PR

- **Merging `build-ios` into the XCTest job.** I recommended it before measuring. The two share no compiled object (device SDK against simulator SDK), so one job would take about 14 min against 10 min of wall clock today. It buys runner minutes and costs restitution time.
- **ccache.** Measured separately and it works — 28 s to 15 s, 46 %, 147/147 hits on the `Pods-example` scheme that CI's 231 s step builds — but it needs its own PR: `brew install ccache` before `pod install`, `CCACHE_BINARY` exported into every `xcodebuild` step (the Podfile hook alone silently no-ops), and a cache on `~/Library/Caches/ccache`. Its CI-side numbers are unmeasured.

Validated with four `workflow_dispatch` runs on the branch, all 8 jobs green each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)